### PR TITLE
ui: fix the error message doesn't show correct

### DIFF
--- a/ui/lib/client/index.tsx
+++ b/ui/lib/client/index.tsx
@@ -39,6 +39,7 @@ export enum ErrorStrategy {
   Default = 'default',
   Custom = 'custom',
 }
+const ERR_CODE_OTHER = 'error.api.other'
 
 function initAxios() {
   i18n.addTranslations(require.context('./translations/', false, /\.yaml$/))
@@ -50,15 +51,18 @@ function initAxios() {
     const method = (config.method as string).toLowerCase()
 
     let errCode: string
+    let content: string
     if (err.message === 'Network Error') {
       errCode = 'error.network'
     } else {
-      errCode = response?.data?.code || 'error.api.other'
-      if (errCode === 'error.api.other') {
-        errCode = response?.data?.message || err.message
-      }
+      errCode = response?.data?.code
     }
-    const content = i18next.t(errCode)
+    if (errCode !== ERR_CODE_OTHER && i18next.exists(errCode)) {
+      content = i18next.t(errCode)
+    } else {
+      content =
+        response?.data?.message || err.message || i18next.t(ERR_CODE_OTHER)
+    }
     err.message = content
 
     if (errCode === 'error.api.unauthorized') {

--- a/ui/lib/components/TextWithInfo/index.tsx
+++ b/ui/lib/components/TextWithInfo/index.tsx
@@ -56,10 +56,12 @@ export interface ITransKeyTextWithInfo {
 }
 
 function TransKey({ transKey, placement, type }: ITransKeyTextWithInfo) {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
   const text = t(transKey)
-  const tooltipKey = `${transKey}_tooltip`
-  const tooltip = i18n.exists(tooltipKey) ? t(tooltipKey) : ''
+  const tooltip = t(`${transKey}_tooltip`, {
+    defaultValue: '',
+    fallbackLng: '_',
+  })
   return (
     <TextWithInfo tooltip={tooltip} placement={placement} type={type}>
       {text}

--- a/ui/lib/components/TextWithInfo/index.tsx
+++ b/ui/lib/components/TextWithInfo/index.tsx
@@ -56,12 +56,10 @@ export interface ITransKeyTextWithInfo {
 }
 
 function TransKey({ transKey, placement, type }: ITransKeyTextWithInfo) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const text = t(transKey)
-  const tooltip = t(`${transKey}_tooltip`, {
-    defaultValue: '',
-    fallbackLng: '_',
-  })
+  const tooltipKey = `${transKey}_tooltip`
+  const tooltip = i18n.exists(tooltipKey) ? t(tooltipKey) : ''
   return (
     <TextWithInfo tooltip={tooltip} placement={placement} type={type}>
       {text}


### PR DESCRIPTION
Reason: 

`i18next.t()` method will truncate some contents and convert colons to dots if the content contains colons.

Example: 

```js
console.log(
  i18next.t('Test: error message with colons: colons will become dots') // error message with colons. colons will become dots
)
```

We also refine the logic a bit. If errCode hasn't a translation, we show the original detail error message instead.