### PR TITLE
*: fix query statement detail error cause by round

### DIFF
--- a/pkg/apiserver/statement/models.go
+++ b/pkg/apiserver/statement/models.go
@@ -42,52 +42,52 @@ type Model struct {
 	AggSumLatency            int    `json:"sum_latency" agg:"SUM(sum_latency)"`
 	AggMaxLatency            int    `json:"max_latency" agg:"MAX(max_latency)"`
 	AggMinLatency            int    `json:"min_latency" agg:"MIN(min_latency)"`
-	AggAvgLatency            int    `json:"avg_latency" agg:"ROUND(SUM(exec_count * avg_latency) / SUM(exec_count))"`
-	AggAvgParseLatency       int    `json:"avg_parse_latency" agg:"ROUND(SUM(exec_count * avg_parse_latency) / SUM(exec_count))"`
+	AggAvgLatency            int    `json:"avg_latency" agg:"CAST(SUM(exec_count * avg_latency) / SUM(exec_count) AS SIGNED)"`
+	AggAvgParseLatency       int    `json:"avg_parse_latency" agg:"CAST(SUM(exec_count * avg_parse_latency) / SUM(exec_count) AS SIGNED)"`
 	AggMaxParseLatency       int    `json:"max_parse_latency" agg:"MAX(max_parse_latency)"`
-	AggAvgCompileLatency     int    `json:"avg_compile_latency" agg:"ROUND(SUM(exec_count * avg_compile_latency) / SUM(exec_count))"`
+	AggAvgCompileLatency     int    `json:"avg_compile_latency" agg:"CAST(SUM(exec_count * avg_compile_latency) / SUM(exec_count) AS SIGNED)"`
 	AggMaxCompileLatency     int    `json:"max_compile_latency" agg:"MAX(max_compile_latency)"`
 	AggSumCopTaskNum         int    `json:"sum_cop_task_num" agg:"SUM(sum_cop_task_num)"`
-	AggAvgCopProcessTime     int    `json:"avg_cop_process_time" agg:"ROUND(SUM(exec_count * avg_process_time) / SUM(sum_cop_task_num))"` // avg process time per copr task
-	AggMaxCopProcessTime     int    `json:"max_cop_process_time" agg:"MAX(max_cop_process_time)"`                                         // max process time per copr task
-	AggAvgCopWaitTime        int    `json:"avg_cop_wait_time" agg:"ROUND(SUM(exec_count * avg_wait_time) / SUM(sum_cop_task_num))"`       // avg wait time per copr task
-	AggMaxCopWaitTime        int    `json:"max_cop_wait_time" agg:"MAX(max_cop_wait_time)"`                                               // max wait time per copr task
-	AggAvgProcessTime        int    `json:"avg_process_time" agg:"ROUND(SUM(exec_count * avg_process_time) / SUM(exec_count))"`           // avg total process time per sql
-	AggMaxProcessTime        int    `json:"max_process_time" agg:"MAX(max_process_time)"`                                                 // max process time per sql
-	AggAvgWaitTime           int    `json:"avg_wait_time" agg:"ROUND(SUM(exec_count * avg_wait_time) / SUM(exec_count))"`                 // avg total wait time per sql
-	AggMaxWaitTime           int    `json:"max_wait_time" agg:"MAX(max_wait_time)"`                                                       // max wait time per sql
-	AggAvgBackoffTime        int    `json:"avg_backoff_time" agg:"ROUND(SUM(exec_count * avg_backoff_time) / SUM(exec_count))"`           // avg total back off time per sql
-	AggMaxBackoffTime        int    `json:"max_backoff_time" agg:"MAX(max_backoff_time)"`                                                 // max back off time per sql
-	AggAvgTotalKeys          int    `json:"avg_total_keys" agg:"ROUND(SUM(exec_count * avg_total_keys) / SUM(exec_count))"`
+	AggAvgCopProcessTime     int    `json:"avg_cop_process_time" agg:"CAST(SUM(exec_count * avg_process_time) / SUM(sum_cop_task_num) AS SIGNED)"` // avg process time per copr task
+	AggMaxCopProcessTime     int    `json:"max_cop_process_time" agg:"MAX(max_cop_process_time)"`                                                  // max process time per copr task
+	AggAvgCopWaitTime        int    `json:"avg_cop_wait_time" agg:"CAST(SUM(exec_count * avg_wait_time) / SUM(sum_cop_task_num) AS SIGNED)"`       // avg wait time per copr task
+	AggMaxCopWaitTime        int    `json:"max_cop_wait_time" agg:"MAX(max_cop_wait_time)"`                                                        // max wait time per copr task
+	AggAvgProcessTime        int    `json:"avg_process_time" agg:"CAST(SUM(exec_count * avg_process_time) / SUM(exec_count) AS SIGNED)"`           // avg total process time per sql
+	AggMaxProcessTime        int    `json:"max_process_time" agg:"MAX(max_process_time)"`                                                          // max process time per sql
+	AggAvgWaitTime           int    `json:"avg_wait_time" agg:"CAST(SUM(exec_count * avg_wait_time) / SUM(exec_count) AS SIGNED)"`                 // avg total wait time per sql
+	AggMaxWaitTime           int    `json:"max_wait_time" agg:"MAX(max_wait_time)"`                                                                // max wait time per sql
+	AggAvgBackoffTime        int    `json:"avg_backoff_time" agg:"CAST(SUM(exec_count * avg_backoff_time) / SUM(exec_count) AS SIGNED)"`           // avg total back off time per sql
+	AggMaxBackoffTime        int    `json:"max_backoff_time" agg:"MAX(max_backoff_time)"`                                                          // max back off time per sql
+	AggAvgTotalKeys          int    `json:"avg_total_keys" agg:"CAST(SUM(exec_count * avg_total_keys) / SUM(exec_count) AS SIGNED)"`
 	AggMaxTotalKeys          int    `json:"max_total_keys" agg:"MAX(max_total_keys)"`
-	AggAvgProcessedKeys      int    `json:"avg_processed_keys" agg:"ROUND(SUM(exec_count * avg_processed_keys) / SUM(exec_count))"`
+	AggAvgProcessedKeys      int    `json:"avg_processed_keys" agg:"CAST(SUM(exec_count * avg_processed_keys) / SUM(exec_count) AS SIGNED)"`
 	AggMaxProcessedKeys      int    `json:"max_processed_keys" agg:"MAX(max_processed_keys)"`
-	AggAvgPrewriteTime       int    `json:"avg_prewrite_time" agg:"ROUND(SUM(exec_count * avg_prewrite_time) / SUM(exec_count))"`
+	AggAvgPrewriteTime       int    `json:"avg_prewrite_time" agg:"CAST(SUM(exec_count * avg_prewrite_time) / SUM(exec_count) AS SIGNED)"`
 	AggMaxPrewriteTime       int    `json:"max_prewrite_time" agg:"MAX(max_prewrite_time)"`
-	AggAvgCommitTime         int    `json:"avg_commit_time" agg:"ROUND(SUM(exec_count * avg_commit_time) / SUM(exec_count))"`
+	AggAvgCommitTime         int    `json:"avg_commit_time" agg:"CAST(SUM(exec_count * avg_commit_time) / SUM(exec_count) AS SIGNED)"`
 	AggMaxCommitTime         int    `json:"max_commit_time" agg:"MAX(max_commit_time)"`
-	AggAvgGetCommitTsTime    int    `json:"avg_get_commit_ts_time" agg:"ROUND(SUM(exec_count * avg_get_commit_ts_time) / SUM(exec_count))"`
+	AggAvgGetCommitTsTime    int    `json:"avg_get_commit_ts_time" agg:"CAST(SUM(exec_count * avg_get_commit_ts_time) / SUM(exec_count) AS SIGNED)"`
 	AggMaxGetCommitTsTime    int    `json:"max_get_commit_ts_time" agg:"MAX(max_get_commit_ts_time)"`
-	AggAvgCommitBackoffTime  int    `json:"avg_commit_backoff_time" agg:"ROUND(SUM(exec_count * avg_commit_backoff_time) / SUM(exec_count))"`
+	AggAvgCommitBackoffTime  int    `json:"avg_commit_backoff_time" agg:"CAST(SUM(exec_count * avg_commit_backoff_time) / SUM(exec_count) AS SIGNED)"`
 	AggMaxCommitBackoffTime  int    `json:"max_commit_backoff_time" agg:"MAX(max_commit_backoff_time)"`
-	AggAvgResolveLockTime    int    `json:"avg_resolve_lock_time" agg:"ROUND(SUM(exec_count * avg_resolve_lock_time) / SUM(exec_count))"`
+	AggAvgResolveLockTime    int    `json:"avg_resolve_lock_time" agg:"CAST(SUM(exec_count * avg_resolve_lock_time) / SUM(exec_count) AS SIGNED)"`
 	AggMaxResolveLockTime    int    `json:"max_resolve_lock_time" agg:"MAX(max_resolve_lock_time)"`
-	AggAvgLocalLatchWaitTime int    `json:"avg_local_latch_wait_time" agg:"ROUND(SUM(exec_count * avg_local_latch_wait_time) / SUM(exec_count))"`
+	AggAvgLocalLatchWaitTime int    `json:"avg_local_latch_wait_time" agg:"CAST(SUM(exec_count * avg_local_latch_wait_time) / SUM(exec_count) AS SIGNED)"`
 	AggMaxLocalLatchWaitTime int    `json:"max_local_latch_wait_time" agg:"MAX(max_local_latch_wait_time)"`
-	AggAvgWriteKeys          int    `json:"avg_write_keys" agg:"ROUND(SUM(exec_count * avg_write_keys) / SUM(exec_count))"`
+	AggAvgWriteKeys          int    `json:"avg_write_keys" agg:"CAST(SUM(exec_count * avg_write_keys) / SUM(exec_count) AS SIGNED)"`
 	AggMaxWriteKeys          int    `json:"max_write_keys" agg:"MAX(max_write_keys)"`
-	AggAvgWriteSize          int    `json:"avg_write_size" agg:"ROUND(SUM(exec_count * avg_write_size) / SUM(exec_count))"`
+	AggAvgWriteSize          int    `json:"avg_write_size" agg:"CAST(SUM(exec_count * avg_write_size) / SUM(exec_count) AS SIGNED)"`
 	AggMaxWriteSize          int    `json:"max_write_size" agg:"MAX(max_write_size)"`
-	AggAvgPrewriteRegions    int    `json:"avg_prewrite_regions" agg:"ROUND(SUM(exec_count * avg_prewrite_regions) / SUM(exec_count))"`
+	AggAvgPrewriteRegions    int    `json:"avg_prewrite_regions" agg:"CAST(SUM(exec_count * avg_prewrite_regions) / SUM(exec_count) AS SIGNED)"`
 	AggMaxPrewriteRegions    int    `json:"max_prewrite_regions" agg:"MAX(max_prewrite_regions)"`
-	AggAvgTxnRetry           int    `json:"avg_txn_retry" agg:"ROUND(SUM(exec_count * avg_txn_retry) / SUM(exec_count))"`
+	AggAvgTxnRetry           int    `json:"avg_txn_retry" agg:"CAST(SUM(exec_count * avg_txn_retry) / SUM(exec_count) AS SIGNED)"`
 	AggMaxTxnRetry           int    `json:"max_txn_retry" agg:"MAX(max_txn_retry)"`
 	AggSumBackoffTimes       int    `json:"sum_backoff_times" agg:"SUM(sum_backoff_times)"`
-	AggAvgMem                int    `json:"avg_mem" agg:"ROUND(SUM(exec_count * avg_mem) / SUM(exec_count))"`
+	AggAvgMem                int    `json:"avg_mem" agg:"CAST(SUM(exec_count * avg_mem) / SUM(exec_count) AS SIGNED)"`
 	AggMaxMem                int    `json:"max_mem" agg:"MAX(max_mem)"`
-	AggAvgDisk               int    `json:"avg_disk" agg:"ROUND(SUM(exec_count * avg_disk) / SUM(exec_count))"`
+	AggAvgDisk               int    `json:"avg_disk" agg:"CAST(SUM(exec_count * avg_disk) / SUM(exec_count) AS SIGNED)"`
 	AggMaxDisk               int    `json:"max_disk" agg:"MAX(max_disk)"`
-	AggAvgAffectedRows       int    `json:"avg_affected_rows" agg:"ROUND(SUM(exec_count * avg_affected_rows) / SUM(exec_count))"`
+	AggAvgAffectedRows       int    `json:"avg_affected_rows" agg:"CAST(SUM(exec_count * avg_affected_rows) / SUM(exec_count) AS SIGNED)"`
 	AggFirstSeen             int    `json:"first_seen" agg:"UNIX_TIMESTAMP(MIN(first_seen))"`
 	AggLastSeen              int    `json:"last_seen" agg:"UNIX_TIMESTAMP(MAX(last_seen))"`
 	AggSampleUser            string `json:"sample_user" agg:"ANY_VALUE(sample_user)"`


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

When query statement detail, dashboard uses to use `ROUND` function to query, but it may cause the flowing error:

![image](https://user-images.githubusercontent.com/26020263/99955243-f0af7980-2dbe-11eb-9672-972992dc730a.png)


This is caused by the `ROUND` function result is `float64`, not `int`, here is an example.


```sql
test> create table t (a int, b double);
Query OK, 0 rows affected
Time: 0.044s
test> insert into t values (62695, 2240325.4838709678),(6, 0.0);
Query OK, 2 rows affected
Time: 0.042s
test> select round(sum(a*b)/sum(a)) as avg from t;
+-----------+
| avg       |
+-----------+
| 2240111.0 |
+-----------+
```

This PR use `CAST( ... AS SIGNED)` function instead of `ROUND` when query statement detail.