### PR TITLE
[DNM] Show trace results in JSON

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gin-gonic/gin v1.5.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/goccy/go-graphviz v0.0.5
+	github.com/gogo/protobuf v1.3.1
 	github.com/google/pprof v0.0.0-20200407044318-7d83b28da2e9
 	github.com/google/uuid v1.0.0
 	github.com/gtank/cryptopasta v0.0.0-20170601214702-1f550f6f2f69
@@ -23,7 +24,7 @@ require (
 	github.com/oleiade/reflections v1.0.0 // indirect
 	github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12
 	github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011
-	github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c
+	github.com/pingcap/kvproto v0.0.0-20201204091901-9f99fec750fc
 	github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd
 	github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011 h1:58naV4XMEqm0h
 github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c h1:wO9VvZezAU4ZPZj8+P5uWfsT/ppuABjJPmHNrpCQnlc=
-github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20201204091901-9f99fec750fc h1:UosPKJGnKfBNV/NO9mxUhlee6ROz7mw0DgXD8254PhI=
+github.com/pingcap/kvproto v0.0.0-20201204091901-9f99fec750fc/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww9rkZ1DnWfl0pXV3BOWlkYIjA=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver/queryeditor"
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver/slowquery"
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver/statement"
+	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver/trace"
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver/user"
 	apiutils "github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver/utils"
 	"github.com/pingcap-incubator/tidb-dashboard/pkg/config"
@@ -123,6 +124,7 @@ func (s *Service) Start(ctx context.Context) error {
 			metrics.NewService,
 			queryeditor.NewService,
 			configuration.NewService,
+			trace.NewService,
 		),
 		fx.Populate(&s.apiHandlerEngine),
 		fx.Invoke(
@@ -138,6 +140,7 @@ func (s *Service) Start(ctx context.Context) error {
 			metrics.RegisterRouter,
 			queryeditor.RegisterRouter,
 			configuration.RegisterRouter,
+			trace.RegisterRouter,
 			// Must be at the end
 			s.status.Register,
 		),

--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -99,6 +99,10 @@ type SlowQuery struct {
 	TotalKeys    uint   `gorm:"column:Total_keys" json:"total_keys"`
 	CopProcAddr  string `gorm:"column:Cop_proc_addr" json:"cop_proc_addr"`
 	CopWaitAddr  string `gorm:"column:Cop_wait_addr" json:"cop_wait_addr"`
+
+	// Tracing
+	// TODO: Switch back to uint64 when modern browser as well as Swagger handles BigInt well.
+	TraceID string `gorm:"column:Trace_ID" json:"trace_id"`
 }
 
 type GetListRequest struct {

--- a/pkg/apiserver/trace/model.go
+++ b/pkg/apiserver/trace/model.go
@@ -1,0 +1,116 @@
+package trace
+
+import (
+	"encoding/json"
+
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+
+	"github.com/pingcap-incubator/tidb-dashboard/pkg/dbstore"
+)
+
+type Model struct {
+	TraceID  int64  `json:"trace_id" gorm:"primary_key"`
+	SpanSets []byte `json:"span_sets" gorm:"type:blob"`
+}
+
+type SpanSet struct {
+	NodeType string `json:"node_type"`
+	Spans    []Span `json:"spans"`
+}
+
+type Span struct {
+	SpanID          uint64     `json:"span_id"`
+	ParentID        uint64     `json:"parent_id"`
+	BeginUnixTimeNs uint64     `json:"begin_unix_time_us"`
+	DurationNs      uint64     `json:"duration_ns"`
+	Event           string     `json:"event"`
+	Properties      []Property `json:"properties,omitempty"`
+}
+
+type Property struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func (Model) TableName() string {
+	return "trace"
+}
+
+func autoMigrate(db *dbstore.DB) error {
+	return db.AutoMigrate(&Model{}).Error
+}
+
+func mapPbToModel(traceID uint64, traceDetail kvrpcpb.TraceDetail) *Model {
+	spanSets := make([]SpanSet, 0, len(traceDetail.SpanSets))
+	for _, set := range traceDetail.SpanSets {
+		if set.TraceId != traceID {
+			// TODO: seems never reach here
+			continue
+		}
+
+		spans := make([]Span, 0, len(set.Spans))
+		idConv := idConverter{idPrefix: set.SpanIdPrefix}
+
+		for _, span := range set.Spans {
+			parentID := idConv.convert(span.ParentId)
+			// Root Span
+			if parentID == 0 {
+				parentID = set.RootParentSpanId
+			}
+
+			spans = append(spans, Span{
+				SpanID:          idConv.convert(span.Id),
+				ParentID:        parentID,
+				BeginUnixTimeNs: span.BeginUnixTimeNs,
+				DurationNs:      span.DurationNs,
+				Event:           span.Event,
+				Properties:      mapProperties(span.Properties),
+			})
+		}
+
+		spanSets = append(spanSets, SpanSet{
+			NodeType: mapNodeType(set.NodeType),
+			Spans:    spans,
+		})
+	}
+
+	spanSetsBytes, _ := json.Marshal(spanSets)
+	return &Model{
+		TraceID:  int64(traceID),
+		SpanSets: spanSetsBytes,
+	}
+}
+
+type idConverter struct {
+	idPrefix uint32
+}
+
+func (c idConverter) convert(prevID uint32) uint64 {
+	return uint64(c.idPrefix)<<32 | uint64(prevID)
+}
+
+func mapProperties(pbProperties []*kvrpcpb.TraceDetail_Span_Property) (res []Property) {
+	for _, p := range pbProperties {
+		res = append(res, Property{
+			Key:   p.Key,
+			Value: p.Value,
+		})
+	}
+
+	return
+}
+
+func mapNodeType(pdNodeType kvrpcpb.TraceDetail_NodeType) (res string) {
+	switch pdNodeType {
+	case kvrpcpb.TraceDetail_TiDB:
+		res = "TiDB"
+	case kvrpcpb.TraceDetail_TiKV:
+		res = "TiKV"
+	case kvrpcpb.TraceDetail_PD:
+		res = "PD"
+	default:
+		res = "Unknown"
+	}
+
+	return
+}

--- a/pkg/apiserver/trace/router.go
+++ b/pkg/apiserver/trace/router.go
@@ -1,0 +1,83 @@
+package trace
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gogo/protobuf/proto"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+
+	"github.com/pingcap-incubator/tidb-dashboard/pkg/apiserver/utils"
+)
+
+func RegisterRouter(r *gin.RouterGroup, s *Service) {
+	endpoint := r.Group("/trace")
+	endpoint.GET("/query/:traceId", s.queryTrace)
+	endpoint.POST("/report", s.reportTrace)
+}
+
+type QueryTraceResponse struct {
+	TraceID  uint64    `json:"trace_id"`
+	SpanSets []SpanSet `json:"span_sets"`
+}
+
+// @Summary Get all span sets with a given trace ID
+// @Param traceId path string true "trace ID"
+// @Success 200 {object} QueryTraceResponse
+// @Failure 400 {object} utils.APIError
+// @Router /trace/query/{traceId} [get]
+func (s *Service) queryTrace(c *gin.Context) {
+	traceID, err := strconv.ParseUint(c.Param("traceId"), 10, 64)
+	if err != nil {
+		utils.MakeInvalidRequestErrorFromError(c, err)
+		return
+	}
+
+	var traceModel = &Model{}
+	if err := s.params.LocalStore.Where("trace_id = ?", int64(traceID)).Find(traceModel).Error; err != nil {
+		utils.MakeInvalidRequestErrorFromError(c, err)
+		return
+	}
+
+	resp := &QueryTraceResponse{TraceID: uint64(traceModel.TraceID)}
+	if err := json.Unmarshal(traceModel.SpanSets, &resp.SpanSets); err != nil {
+		utils.MakeInvalidRequestErrorFromError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+type ReportRequest struct {
+	TraceID     uint64 `json:"trace_id"`
+	TraceDetail []byte `json:"trace_detail"`
+}
+
+// @Summary Report tracing results
+// @Param req body ReportRequest true "Request body"
+// @Success 200 {object} utils.APIEmptyResponse
+// @Failure 400 {object} utils.APIError
+// @Router /trace/report [post]
+func (s *Service) reportTrace(c *gin.Context) {
+	var req ReportRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.MakeInvalidRequestErrorFromError(c, err)
+		return
+	}
+
+	traceDetail := kvrpcpb.TraceDetail{}
+	if err := proto.Unmarshal(req.TraceDetail, &traceDetail); err != nil {
+		utils.MakeInvalidRequestErrorFromError(c, err)
+		return
+	}
+
+	model := mapPbToModel(req.TraceID, traceDetail)
+	if err := s.params.LocalStore.Create(&model).Error; err != nil {
+		utils.MakeInvalidRequestErrorFromError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, utils.APIEmptyResponse{})
+}

--- a/pkg/apiserver/trace/service.go
+++ b/pkg/apiserver/trace/service.go
@@ -1,0 +1,26 @@
+package trace
+
+import (
+	"github.com/pingcap/log"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+
+	"github.com/pingcap-incubator/tidb-dashboard/pkg/dbstore"
+)
+
+type ServiceParams struct {
+	fx.In
+	LocalStore *dbstore.DB
+}
+
+type Service struct {
+	params ServiceParams
+}
+
+func NewService(p ServiceParams) *Service {
+	err := autoMigrate(p.LocalStore)
+	if err != nil {
+		log.Fatal("Failed to initialize database", zap.Error(err))
+	}
+	return &Service{params: p}
+}

--- a/ui/lib/apps/SlowQuery/pages/Detail/DetailTabBasic.tsx
+++ b/ui/lib/apps/SlowQuery/pages/Detail/DetailTabBasic.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { SlowquerySlowQuery } from '@lib/client'
+import client, { SlowquerySlowQuery } from '@lib/client'
 import { CardTable, DateTime } from '@lib/components'
 import { getValueFormat } from '@baurine/grafana-value-formats'
 import { valueColumns } from '@lib/utils/tableColumns'
@@ -37,6 +37,23 @@ export default function TabBasic({ data }: ITabBasicProps) {
     { key: 'connection_id', value: data.connection_id },
     { key: 'user', value: data.user },
     { key: 'host', value: data.host },
+    {
+      key: 'trace_id',
+      value: (
+        <a
+          onClick={() => {
+            if (data.trace_id && data.trace_id !== '0') {
+              window.open(
+                `${client.getBasePath()}/trace/query/${data.trace_id}`,
+                '_blank'
+              )
+            }
+          }}
+        >
+          {data.trace_id}
+        </a>
+      ),
+    },
   ]
   const columns = valueColumns('slow_query.fields.')
   return (

--- a/ui/lib/apps/SlowQuery/translations/en.yaml
+++ b/ui/lib/apps/SlowQuery/translations/en.yaml
@@ -33,6 +33,8 @@ slow_query:
     host_tooltip: The address of the client that sends the query
     db: Execution Database
     db_tooltip: The database used to execute the query
+    trace_id: Trace ID
+    trace_id_tooltip: Unique trace ID of the query
 
     query_time2: Query Time
     query_time2_tooltip: The elapsed wall time when execution the query

--- a/ui/lib/apps/SlowQuery/translations/zh.yaml
+++ b/ui/lib/apps/SlowQuery/translations/zh.yaml
@@ -33,6 +33,8 @@ slow_query:
     host_tooltip: 发送 SQL 查询的客户端地址
     db: 执行数据库
     db_tooltip: 执行该 SQL 查询时使用的数据库名称
+    trace_id: 追踪 ID
+    trace_id_tooltip: SQL 查询追踪 ID
 
     query_time2: SQL 执行时间
     query_time2_tooltip: 执行 SQL 耗费的自然时间


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

This PR is for fetching trace results easily.

## Setup

First, follow the description at https://github.com/pingcap/tidb/pull/19557 to set up TiDB cluster with tracing feature, but with the following TiDB config:

```
[trace]
jaeger-thrift-compact-agent = "127.0.0.1:6831"
datadog-agent = "127.0.0.1:8126"
dashboard-agent = "127.0.0.1:12333"
max-spans-length = 2000
```

Second, use this branch to set up the dashboard developing environment.

Third, try to produce some slow logs.

## Experience

Open http://127.0.0.1:12333/dashboard/#/slow_query.

![Screenshot from 2020-12-05 00-53-45](https://user-images.githubusercontent.com/29565014/101191373-8f2bbc80-3694-11eb-9803-06665f550eb2.png)

Click any slow log you like. Scroll to the bottom then you can see `Trace ID`.

![Screenshot from 2020-12-05 00-53-59](https://user-images.githubusercontent.com/29565014/101191561-c8642c80-3694-11eb-8f30-ec4c154302d2.png)

Click the ID, you will get the JSON:

![Screenshot from 2020-12-05 00-54-20](https://user-images.githubusercontent.com/29565014/101191849-31e43b00-3695-11eb-8d77-d5d8513d09de.png)


## Comparison

While TiDB gets JSON, let's see what're in Jaeger and Datadog:

![Screenshot from 2020-12-05 01-02-34](https://user-images.githubusercontent.com/29565014/101192285-d1a1c900-3695-11eb-9b21-3e93b4114e97.png)

![Screenshot from 2020-12-05 01-04-00](https://user-images.githubusercontent.com/29565014/101192295-d6667d00-3695-11eb-82c2-85bb06aa8c2b.png)

Good luck! @baurine 