### PR TITLE
fix duplicated y-axis label

### DIFF
--- a/ui/lib/components/MetricChart/index.tsx
+++ b/ui/lib/components/MetricChart/index.tsx
@@ -198,7 +198,7 @@ export default function MetricChart({
         type: 'value',
         axisLabel: {
           formatter: (v) => {
-            return valueFormatter(v, 0)
+            return valueFormatter(v, 1)
           },
         },
         splitLine: {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/5772358/101757746-7bf47300-3b12-11eb-8b71-0ba8527c63ce.png)

Instead of changing the format library or removing duplicate labels, it is much simpler to just increase the precision

close #821