### PR TITLE
show indents for slow query detail time more elegantly

### DIFF
--- a/ui/lib/apps/SlowQuery/pages/Detail/DetailTabTime.tsx
+++ b/ui/lib/apps/SlowQuery/pages/Detail/DetailTabTime.tsx
@@ -20,86 +20,107 @@ export default function TabBasic({ data }: ITabTimeProps) {
         </Typography.Text>
       ),
       value: data.query_time! * 10e8,
+      indentLevel: 0,
     },
     {
       key: 'parse_time',
       value: data.parse_time! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'compile_time',
       value: data.compile_time! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'rewrite_time',
       value: data.rewrite_time! * 10e8,
+      indentLevel: 2,
     },
     {
       key: 'preproc_subqueries_time',
       value: data.preproc_subqueries_time! * 10e8,
+      indentLevel: 3,
     },
     {
       key: 'optimize_time',
       value: data.optimize_time! * 10e8,
+      indentLevel: 2,
     },
     {
       key: 'cop_time',
       value: data.cop_time! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'wait_time',
       value: data.wait_time! * 10e8,
+      indentLevel: 2,
     },
     {
       key: 'process_time',
       value: data.process_time! * 10e8,
+      indentLevel: 2,
     },
     {
       key: 'local_latch_wait_time',
       value: data.local_latch_wait_time! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'lock_keys_time',
       value: data.lock_keys_time! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'resolve_lock_time',
       value: data.resolve_lock_time! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'wait_ts',
       value: data.wait_ts! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'get_commit_ts_time',
       value: data.get_commit_ts_time! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'prewrite_time',
       value: data.prewrite_time! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'commit_time',
       value: data.commit_time! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'backoff_time',
       value: data.backoff_time! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'commit_backoff_time',
       value: data.commit_backoff_time! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'exec_retry_time',
       value: data.exec_retry_time! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'write_sql_response_total',
       value: data.write_sql_response_total! * 10e8,
+      indentLevel: 1,
     },
     {
       key: 'wait_prewrite_binlog_time',
       value: data.wait_prewrite_binlog_time! * 10e8,
+      indentLevel: 1,
     },
   ]
   const columns = timeValueColumns('slow_query.fields.', items)

--- a/ui/lib/apps/SlowQuery/translations/en.yaml
+++ b/ui/lib/apps/SlowQuery/translations/en.yaml
@@ -36,42 +36,42 @@ slow_query:
 
     query_time2: Query Time
     query_time2_tooltip: The elapsed wall time when execution the query
-    parse_time: 　　Parse Time
+    parse_time: Parse Time
     parse_time_tooltip: Time consumed when parsing the query
-    compile_time: 　　Generate Plan Time
-    rewrite_time: 　　　　Rewrite Plan Time
-    preproc_subqueries_time: 　　　　　　Preprocess Sub-Query Time
+    compile_time: Generate Plan Time
+    rewrite_time: Rewrite Plan Time
+    preproc_subqueries_time: Preprocess Sub-Query Time
     preproc_subqueries_time_tooltip: Time consumed when pre-processing the subquery during the rewrite plan phase
-    optimize_time: 　　　　Optimize Plan Time
-    wait_ts: 　　Get Start Ts Time
+    optimize_time: Optimize Plan Time
+    wait_ts: Get Start Ts Time
     wait_ts_tooltip: Time consumed when getting a start timestamp when transaction begins
-    cop_time: 　　Coprocessor Executor Time
+    cop_time: Coprocessor Executor Time
     cop_time_tooltip: 'The elapsed wall time when TiDB Coprocessor executor waiting all Coprocessor requests to finish (note: when there are JOIN in SQL statement, multiple TiDB Coprocessor executors may be running in parallel, which may cause this time not being a wall time)'
-    wait_time: 　　　　Coprocessor Wait Time
+    wait_time: Coprocessor Wait Time
     wait_time_tooltip: 'The total time of Coprocessor request is prepared and wait to execute in TiKV, which may happen when retrieving a snapshot though Raft concensus protocol (note: TiKV waits requests in parallel so that this is not a wall time)'
-    process_time: 　　　　Coprocessor Process Time
+    process_time: Coprocessor Process Time
     process_time_tooltip: 'The total time of Coprocessor request being executed in TiKV (note: TiKV executes requests in parallel so that this is not a wall time)'
-    backoff_time: 　　Execution Backoff Time
+    backoff_time: Execution Backoff Time
     backoff_time_tooltip: 'The total backoff waiting time before retry when a query encounters errors (note: there may be multiple backoffs in parallel so that this may not be a wall time)'
-    lock_keys_time: 　　Lock Keys Time
+    lock_keys_time: Lock Keys Time
     lock_keys_time_tooltip: Time consumed when locking keys in pessimistic transaction
-    get_commit_ts_time: 　　Get Commit Ts Time
+    get_commit_ts_time: Get Commit Ts Time
     get_commit_ts_time_tooltip: Time consumed when getting a commit timestamp for 2PC commit phase when transaction commits
-    local_latch_wait_time: 　　Local Latch Wait Time
+    local_latch_wait_time: Local Latch Wait Time
     local_latch_wait_time_tooltip: Time consumed when TiDB waits for the lock in the current TiDB instance before 2PC commit phase when transaction commits
-    resolve_lock_time: 　　Resolve Lock Time
+    resolve_lock_time: Resolve Lock Time
     resolve_lock_time_tooltip: Time consumed when TiDB resolves locks from other transactions in 2PC prewrite phase when transaction commits
-    prewrite_time: 　　Prewrite Time
+    prewrite_time: Prewrite Time
     prewrite_time_tooltip: Time consumed in 2PC prewrite phase when transaction commits
-    wait_prewrite_binlog_time: 　　Wait Binlog Prewrite Time
+    wait_prewrite_binlog_time: Wait Binlog Prewrite Time
     wait_prewrite_binlog_time_tooltip: Time consumed when waiting Binlog prewrite to finish
-    commit_time: 　　Commit Time
+    commit_time: Commit Time
     commit_time_tooltip: Time consumed in 2PC commit phase when transaction commits
-    commit_backoff_time: 　　Commit Backoff Time
+    commit_backoff_time: Commit Backoff Time
     commit_backoff_time_tooltip: 'The total backoff waiting time when 2PC commit encounters errors (note: there may be multiple backoffs in parallel so that this may not be a wall time)'
-    write_sql_response_total: 　　Send response Time
+    write_sql_response_total: Send response Time
     write_sql_response_total_tooltip: Time consumed when sending response to the SQL client
-    exec_retry_time: 　　Retried execution Time
+    exec_retry_time: Retried execution Time
     exec_retry_time_tooltip: Wall time consumed when SQL statement is retried and executed again, except for the last exection
 
     request_count: Request Count

--- a/ui/lib/apps/SlowQuery/translations/zh.yaml
+++ b/ui/lib/apps/SlowQuery/translations/zh.yaml
@@ -36,44 +36,44 @@ slow_query:
 
     query_time2: SQL 执行时间
     query_time2_tooltip: 执行 SQL 耗费的自然时间
-    parse_time: 　　解析耗时
+    parse_time: 解析耗时
     parse_time_tooltip: 解析该 SQL 查询的耗时
-    compile_time: 　　生成执行计划耗时
+    compile_time: 生成执行计划耗时
     compile_time_tooltip: 生成该 SQL 的执行计划的耗时
-    rewrite_time: 　　　　重写执行计划耗时
+    rewrite_time: 重写执行计划耗时
     rewrite_time_tooltip: 重写执行计划的耗时，例如常量折叠等
-    preproc_subqueries_time: 　　　　　　子查询预处理耗时
-    optimize_time: 　　　　优化执行计划耗时
+    preproc_subqueries_time: 子查询预处理耗时
+    optimize_time: 优化执行计划耗时
     optimize_time_tooltip: 优化器寻找执行计划的耗时，包括规则优化和物理优化的耗时
-    wait_ts: 　　取事务 Start Ts 耗时
+    wait_ts: 取事务 Start Ts 耗时
     wait_ts_tooltip: 从 PD 取事务开始时间戳步骤的耗时
-    cop_time: 　　Coprocessor 执行耗时
+    cop_time: Coprocessor 执行耗时
     cop_time_tooltip: TiDB Coprocessor 算子等待所有任务在 TiKV 上并行执行完毕耗费的自然时间（注：当 SQL 语句中包含 JOIN 时，多个 TiDB Coprocessor 算子可能会并行执行，此时不再等同于自然时间）
-    wait_time: 　　　　Coprocessor 累计等待耗时
+    wait_time: Coprocessor 累计等待耗时
     wait_time_tooltip: TiKV 准备并等待 Coprocessor 任务执行的累计时间，等待过程中包括通过 Raft 一致性协议取快照等（注：TiKV 会并行等待任务，因此该时间不是自然流逝时间）
-    process_time: 　　　　Coprocessor 累计执行耗时
+    process_time: Coprocessor 累计执行耗时
     process_time_tooltip: TiKV 执行 Coprocessor 任务的累计处理时间（注：TiKV 会并行处理任务，因此该时间不是自然流逝时间）
-    lock_keys_time: 　　上锁耗时
+    lock_keys_time: 上锁耗时
     lock_keys_time_tooltip: 悲观事务中对相关行数据进行上锁的耗时
-    backoff_time: 　　执行阶段累计 Backoff 耗时
+    backoff_time: 执行阶段累计 Backoff 耗时
     backoff_time_tooltip: 在执行失败时，Backoff 机制等待一段时间再重试时的 Backoff 累计耗时（注：可能同时存在多个 Backoff，因此该时间可能不是自然流逝时间）
-    get_commit_ts_time: 　　取事务 Commit Ts 耗时
+    get_commit_ts_time: 取事务 Commit Ts 耗时
     get_commit_ts_time_tooltip: 从 PD 取提交时间戳（事务号）步骤的耗时
-    local_latch_wait_time: 　　TiDB 本地等锁耗时
+    local_latch_wait_time: TiDB 本地等锁耗时
     local_latch_wait_time_tooltip: 事务在 TiDB 本地与其他事务产生了锁冲突并等待的耗时
-    resolve_lock_time: 　　解锁耗时
+    resolve_lock_time: 解锁耗时
     resolve_lock_time_tooltip: 事务在提交过程中与其他事务产生了锁冲突并处理锁冲突的耗时
-    prewrite_time: 　　Prewrite 阶段耗时
+    prewrite_time: Prewrite 阶段耗时
     prewrite_time_tooltip: 事务两阶段提交中第一阶段（prewrite 阶段）的耗时
-    wait_prewrite_binlog_time: 　　Binlog Prewrite 等待耗时
+    wait_prewrite_binlog_time: Binlog Prewrite 等待耗时
     wait_prewrite_binlog_time_tooltip: 等待 Binlog Prewrite 完成的耗时
-    commit_time: 　　Commit 阶段耗时
+    commit_time: Commit 阶段耗时
     commit_time_tooltip: 事务两阶段提交中第二阶段（commit 阶段）的耗时
-    commit_backoff_time: 　　Commit 阶段累计 Backoff 耗时
+    commit_backoff_time: Commit 阶段累计 Backoff 耗时
     commit_backoff_time_tooltip: 事务递交失败时，Backoff 机制等待一段时间再重试时的 Backoff 累计耗时（注：可能同时存在多个 Backoff，因此该时间可能不是自然流逝时间）
-    write_sql_response_total: 　　发送结果耗时
+    write_sql_response_total: 发送结果耗时
     write_sql_response_total_tooltip: 发送 SQL 语句执行结果给客户端的耗时
-    exec_retry_time: 　　前序执行耗时
+    exec_retry_time: 前序执行耗时
     exec_retry_time_tooltip: 由于锁冲突或错误，计划可能会执行失败并重试执行多次，该时间是不包含最后一次执行的前序执行自然时间（注：执行计划中的时间不含该前序时间）
 
     request_count: Coprocessor 请求数

--- a/ui/lib/components/TextWithInfo/index.tsx
+++ b/ui/lib/components/TextWithInfo/index.tsx
@@ -64,7 +64,7 @@ function TransKey({ transKey, placement, type }: ITransKeyTextWithInfo) {
   })
   return (
     <TextWithInfo tooltip={tooltip} placement={placement} type={type}>
-      {text.trim()}
+      {text}
     </TextWithInfo>
   )
 }

--- a/ui/lib/components/TextWithInfo/index.tsx
+++ b/ui/lib/components/TextWithInfo/index.tsx
@@ -64,7 +64,7 @@ function TransKey({ transKey, placement, type }: ITransKeyTextWithInfo) {
   })
   return (
     <TextWithInfo tooltip={tooltip} placement={placement} type={type}>
-      {text}
+      {text.trim()}
     </TextWithInfo>
   )
 }

--- a/ui/lib/utils/tableColumns.tsx
+++ b/ui/lib/utils/tableColumns.tsx
@@ -60,12 +60,9 @@ function fieldsKeyColumn(transKeyPrefix: string): IColumn {
     minWidth: 150,
     maxWidth: 250,
     onRender: (rec) => {
-      const indent = Array(rec.indentLevel || 0)
-        .fill('\t')
-        .join('')
       return (
         <>
-          <span style={{ whiteSpace: 'pre' }}>{indent}</span>
+          <span style={{ paddingLeft: (rec.indentLevel || 0) * 24 }}></span>
           {rec.keyDisplay ?? (
             <TransText transKey={`${transKeyPrefix}${rec.key}`} />
           )}

--- a/ui/lib/utils/tableColumns.tsx
+++ b/ui/lib/utils/tableColumns.tsx
@@ -61,12 +61,11 @@ function fieldsKeyColumn(transKeyPrefix: string): IColumn {
     maxWidth: 250,
     onRender: (rec) => {
       return (
-        <>
-          <span style={{ paddingLeft: (rec.indentLevel || 0) * 24 }}></span>
+        <div style={{ paddingLeft: (rec.indentLevel || 0) * 24 }}>
           {rec.keyDisplay ?? (
             <TransText transKey={`${transKeyPrefix}${rec.key}`} />
           )}
-        </>
+        </div>
       )
     },
   }

--- a/ui/lib/utils/tableColumns.tsx
+++ b/ui/lib/utils/tableColumns.tsx
@@ -60,10 +60,17 @@ function fieldsKeyColumn(transKeyPrefix: string): IColumn {
     minWidth: 150,
     maxWidth: 250,
     onRender: (rec) => {
-      if (rec.keyDisplay) {
-        return rec.keyDisplay
-      }
-      return <TransText transKey={`${transKeyPrefix}${rec.key}`} />
+      const indent = Array(rec.indentLevel || 0)
+        .fill('\t')
+        .join('')
+      return (
+        <>
+          <span style={{ whiteSpace: 'pre' }}>{indent}</span>
+          {rec.keyDisplay ?? (
+            <TransText transKey={`${transKeyPrefix}${rec.key}`} />
+          )}
+        </>
+      )
     },
   }
 }


### PR DESCRIPTION
Before:

<img width="323" alt="WeCom20201224-161739@2x" src="https://user-images.githubusercontent.com/1284531/103074438-8d567880-4604-11eb-933e-5745fd8ce578.png">

After:

<img width="300" alt="WeCom20201224-161807@2x" src="https://user-images.githubusercontent.com/1284531/103074454-95aeb380-4604-11eb-8e40-73c814409e85.png">

![image](https://user-images.githubusercontent.com/1284531/103078053-03aaa900-460c-11eb-90d0-4b9858cac47a.png)
