### PR TITLE
optimize slow-query list performance

### DIFF
--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -219,24 +219,10 @@ func QuerySlowLogList(db *gorm.DB, req *GetListRequest) ([]SlowQuery, error) {
 		tx = tx.Where("DB IN (?)", req.DB)
 	}
 
-	// more robust
-	if req.OrderBy == "" {
-		req.OrderBy = "timestamp"
-	}
-
-	order, err := getProjectionsByFields(req.OrderBy)
-	if err != nil {
-		return nil, err
-	}
-	// to handle the special case: timestamp
-	// if req.OrderBy is "timestamp", then the order is "(unix_timestamp(Time) + 0E0) AS timestamp"
-	if strings.Contains(order[0], " AS ") {
-		order[0] = req.OrderBy
-	}
 	if req.IsDesc {
-		tx = tx.Order(fmt.Sprintf("%s DESC", order[0]))
+		tx = tx.Order("Time DESC")
 	} else {
-		tx = tx.Order(fmt.Sprintf("%s ASC", order[0]))
+		tx = tx.Order("Time ASC")
 	}
 
 	if len(req.Plans) > 0 {


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

convert slow query list SQL from:

```sql
SELECT Digest, ...... ORDER BY timestamp DESC LIMIT 100
```

to 

```sql
SELECT Digest, ...... ORDER BY Time DESC LIMIT 100
```

The related query plan change from 

```sql
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| tidb_decode_plan('sA3oMAkzXzcJMAkxMDAJaW5mb3JtYXRpb25fc2NoZW1hLmNsdXN0ZXJfc2xvd19xdWVyeS5kaWdlc3QsIGmSLgCIY29ubl9pZCwgcGx1cyhjYXN0KHVuaXhfdGltZXN0YW1wKGmSSAABMIApLCBkb3VibGUgQklOQVJZKSwgMCktPkNvbHVtbiM3MSyalAAQcXVlcnmyLQAFr54yABhtZW1fbWF4JVMBt9A6NDAxLjRtcy                                                                                                                                                                                                                                                                                                                                                        |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|     id                              task         estRows    operator info                                                                                                                                                                                                                                                                                                                                                                                 actRows    execution info                                                                                                                     memory     disk |
|     Projection_7                    root         100        information_schema.cluster_slow_query.digest, information_schema.cluster_slow_query.conn_id, plus(cast(unix_timestamp(information_schema.cluster_slow_query.time), double BINARY), 0)->Column#71, information_schema.cluster_slow_query.query, information_schema.cluster_slow_query.query_time, information_schema.cluster_slow_query.mem_max                                                100        time:401.4ms, loops:2, Concurrency:OFF                                                                                             19.6 KB    N/A  |
|     └─Projection_17                 root         100        information_schema.cluster_slow_query.time, information_schema.cluster_slow_query.conn_id, information_schema.cluster_slow_query.query_time, information_schema.cluster_slow_query.digest, information_schema.cluster_slow_query.mem_max, information_schema.cluster_slow_query.query                                                                                                         100        time:401.3ms, loops:2, Concurrency:OFF                                                                                             19.5 KB    N/A  |
|       └─TopN_8                      root         100        Column#72:desc, offset:0, count:100                                                                                                                                                                                                                                                                                                                                                           100        time:401.3ms, loops:2                                                                                                              8.69 MB    N/A  |
|         └─Projection_18             root         250        information_schema.cluster_slow_query.time, information_schema.cluster_slow_query.conn_id, information_schema.cluster_slow_query.query_time, information_schema.cluster_slow_query.digest, information_schema.cluster_slow_query.mem_max, information_schema.cluster_slow_query.query, plus(cast(unix_timestamp(information_schema.cluster_slow_query.time), double BINARY), 0)->Column#72    40136      time:380.4ms, loops:42, Concurrency:OFF                                                                                            1.45 MB    N/A  |
|           └─TableReader_13          root         250        data:Selection_12                                                                                                                                                                                                                                                                                                                                                                             40136      time:361.4ms, loops:42, cop_task: {num: 1, max: 358.1ms, proc_keys: 0, rpc_num: 1, rpc_time: 358ms, copr_cache_hit_ratio: 0.00}    7.35 MB    N/A  |
|             └─Selection_12          cop[tidb]    250        ge(information_schema.cluster_slow_query.time, 2021-01-04 14:01:16), le(information_schema.cluster_slow_query.time, 2021-01-04 14:31:16)                                                                                                                                                                                                                                                      0                                                                                                                                             N/A        N/A  |
|               └─TableFullScan_11    cop[tidb]    10000      table:CLUSTER_SLOW_QUERY, keep order:false, stats:pseudo                                                                                                                                                                                                                                                                                                                                      0                                                                                                                                             N/A        N/A  |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

```

To 

```sql
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| tidb_decode_plan('yAboMAkzXzkJMAkxMDAJaW5mb3JtYXRpb25fc2NoZW1hLmNsdXN0ZXJfc2xvd19xdWVyeS5kaWdlc3QsIGmSLgCIY29ubl9pZCwgcGx1cyhjYXN0KHVuaXhfdGltZXN0YW1wKGmSSAABMIApLCBkb3VibGUgQklOQVJZKSwgMCktPkNvbHVtbiM3MCyalAAQcXVlcnmyLQAFr54yABhtZW1fbWF4JVMBt9A6MTQ5bXMsIG                                                                                                                                                                                                                                                                                                          |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|     id                           task         estRows    operator info                                                                                                                                                                                                                                                                                                                                     actRows    execution info                                                                                                                      memory     disk |
|     Projection_9                 root         100        information_schema.cluster_slow_query.digest, information_schema.cluster_slow_query.conn_id, plus(cast(unix_timestamp(information_schema.cluster_slow_query.time), double BINARY), 0)->Column#70, information_schema.cluster_slow_query.query, information_schema.cluster_slow_query.query_time, information_schema.cluster_slow_query.mem_max    100        time:149ms, loops:2, Concurrency:OFF                                                                                                23.5 KB    N/A  |
|     └─Limit_13                   root         100        offset:0, count:100                                                                                                                                                                                                                                                                                                                               100        time:148.9ms, loops:2                                                                                                               N/A        N/A  |
|       └─TableReader_23           root         100        data:Limit_22                                                                                                                                                                                                                                                                                                                                     100        time:148.9ms, loops:1, cop_task: {num: 1, max: 148.8ms, proc_keys: 0, rpc_num: 1, rpc_time: 148.7ms, copr_cache_hit_ratio: 0.00}    18.9 KB    N/A  |
|         └─Limit_22               cop[tidb]    100        offset:0, count:100                                                                                                                                                                                                                                                                                                                               0                                                                                                                                              N/A        N/A  |
|           └─TableRangeScan_21    cop[tidb]    100        table:CLUSTER_SLOW_QUERY, range:[2021-01-04 14:13:43.000000,2021-01-04 14:43:43.000000], keep order:true, desc, stats:pseudo                                                                                                                                                                                                                      0                                                                                                                                              N/A        N/A  |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

This PR is related to https://github.com/pingcap/tidb/pull/20750.