### PR TITLE
fix slow query bug when order by other fields

### DIFF
--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -234,6 +234,7 @@ func QuerySlowLogList(db *gorm.DB, req *GetListRequest) ([]SlowQuery, error) {
 		order[0] = req.OrderBy
 	}
 	if order[0] == "timestamp" {
+		// Order by column instead of expression, see related optimization in TiDB: https://github.com/pingcap/tidb/pull/20750
 		order[0] = "Time"
 	}
 

--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -219,10 +219,24 @@ func QuerySlowLogList(db *gorm.DB, req *GetListRequest) ([]SlowQuery, error) {
 		tx = tx.Where("DB IN (?)", req.DB)
 	}
 
+	// more robust
+	if req.OrderBy == "" {
+		req.OrderBy = "timestamp"
+	}
+
+	order, err := getProjectionsByFields(req.OrderBy)
+	if err != nil {
+		return nil, err
+	}
+	// to handle the special case: timestamp
+	// if req.OrderBy is "timestamp", then the order is "(unix_timestamp(Time) + 0E0) AS timestamp"
+	if strings.Contains(order[0], " AS ") {
+		order[0] = req.OrderBy
+	}
 	if req.IsDesc {
-		tx = tx.Order("Time DESC")
+		tx = tx.Order(fmt.Sprintf("%s DESC", order[0]))
 	} else {
-		tx = tx.Order("Time ASC")
+		tx = tx.Order(fmt.Sprintf("%s ASC", order[0]))
 	}
 
 	if len(req.Plans) > 0 {

--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -233,6 +233,10 @@ func QuerySlowLogList(db *gorm.DB, req *GetListRequest) ([]SlowQuery, error) {
 	if strings.Contains(order[0], " AS ") {
 		order[0] = req.OrderBy
 	}
+	if order[0] == "timestamp" {
+		order[0] = "Time"
+	}
+
 	if req.IsDesc {
 		tx = tx.Order(fmt.Sprintf("%s DESC", order[0]))
 	} else {


### PR DESCRIPTION
1. revert #835
2. Only convert to `ORDER BY TIME` when the original is `ORDER BY timestamp`