### PR TITLE
keyviz: fix the bug that sometimes the table info cannot be obtained

### DIFF
--- a/pkg/keyvisual/decorator/tidb_requests.go
+++ b/pkg/keyvisual/decorator/tidb_requests.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -73,7 +74,8 @@ func (s *tidbLabelStrategy) updateMap(ctx context.Context) {
 			continue
 		}
 		var tableInfos []*model.TableInfo
-		if err := s.request(fmt.Sprintf("/schema/%s", db.Name.O), &tableInfos); err != nil {
+		encodeName := url.PathEscape(db.Name.O)
+		if err := s.request(fmt.Sprintf("/schema/%s", encodeName), &tableInfos); err != nil {
 			log.Error("fail to send schema request to TiDB", zap.Error(err))
 			updateSuccess = false
 			continue


### PR DESCRIPTION
Signed-off-by: Zheng Xiangsheng <hundundm@gmail.com>

* keyviz: fix the bug that table info cannot be obtained if the database name contains special chars.
* Before:
  * ![image](https://user-images.githubusercontent.com/19789302/103658101-bd5b2f80-4fa5-11eb-9a27-12e2f1cf7016.png)
* After:
  * ![image](https://user-images.githubusercontent.com/19789302/103658169-d4018680-4fa5-11eb-9996-bbc3fe574161.png)

