### PR TITLE
config: fix the bug that sometimes the dynamic config cannot be obtained

### DIFF
--- a/pkg/config/dynamic_config_manager.go
+++ b/pkg/config/dynamic_config_manager.go
@@ -30,7 +30,8 @@ import (
 const (
 	DynamicConfigPath = "/dashboard/dynamic_config"
 	Timeout           = time.Second
-	MaxCheckInterval  = 5 * time.Second
+	MaxCheckInterval  = 30 * time.Second
+	MaxElapsedTime    = 0 // never stop if MaxElapsedTime == 0
 )
 
 var (
@@ -71,6 +72,7 @@ func (m *DynamicConfigManager) Start(ctx context.Context) error {
 		var dc *DynamicConfig
 		ebo := backoff.NewExponentialBackOff()
 		ebo.MaxInterval = MaxCheckInterval
+		ebo.MaxElapsedTime = MaxElapsedTime
 		bo := backoff.WithContext(ebo, ctx)
 
 		if err := backoff.Retry(func() error {


### PR DESCRIPTION
Signed-off-by: Zheng Xiangsheng <hundundm@gmail.com>

* config: fix the bug that the dynamic config cannot be obtained when the PD starts later than the dashboard server

After the dashboard server is started, if the PD starts after 15 minutes, the dynamic config cannot be obtained normally and some services cannot be used. This PR fixes this bug.