### PR TITLE
remember the coarse scrolled position for statements and slow queries list

### DIFF
--- a/ui/lib/apps/SlowQuery/components/SlowQueriesTable.tsx
+++ b/ui/lib/apps/SlowQuery/components/SlowQueriesTable.tsx
@@ -19,11 +19,15 @@ function SlowQueriesTable({ controller, ...restProps }: Props) {
     changeOrder,
     errors,
     visibleColumnKeys,
+
+    saveClickedItemIndex,
+    getClickedItemIndex,
   } = controller
 
   const navigate = useNavigate()
   const handleRowClick = usePersistFn(
-    (rec, _idx, ev: React.MouseEvent<HTMLElement>) => {
+    (rec, idx, ev: React.MouseEvent<HTMLElement>) => {
+      saveClickedItemIndex(idx)
       const qs = DetailPage.buildQuery({
         digest: rec.digest,
         connectId: rec.connection_id,
@@ -47,6 +51,7 @@ function SlowQueriesTable({ controller, ...restProps }: Props) {
       errors={errors}
       visibleColumnKeys={visibleColumnKeys}
       onRowClicked={handleRowClick}
+      clickedRowIndex={getClickedItemIndex()}
       getKey={getKey}
     />
   )

--- a/ui/lib/apps/SlowQuery/index.tsx
+++ b/ui/lib/apps/SlowQuery/index.tsx
@@ -6,7 +6,7 @@ import useCache, { CacheContext } from '@lib/utils/useCache'
 import { List, Detail } from './pages'
 
 export default function () {
-  const slowQueryCacheMgr = useCache()
+  const slowQueryCacheMgr = useCache(2)
 
   return (
     <Root>

--- a/ui/lib/apps/SlowQuery/utils/useSlowQueryTableController.ts
+++ b/ui/lib/apps/SlowQuery/utils/useSlowQueryTableController.ts
@@ -13,6 +13,7 @@ import useOrderState, { IOrderOptions } from '@lib/utils/useOrderState'
 
 import { getSelectedFields } from '@lib/utils/tableColumnFactory'
 import { CacheMgr } from '@lib/utils/useCache'
+import useCacheItemIndex from '@lib/utils/useCacheItemIndex'
 
 import { derivedFields, slowQueryColumns } from './tableColumns'
 
@@ -69,6 +70,9 @@ export interface ISlowQueryTableController {
 
   downloadCSV: () => Promise<void>
   downloading: boolean
+
+  saveClickedItemIndex: (idx: number) => void
+  getClickedItemIndex: () => number
 }
 
 export default function useSlowQueryTableController(
@@ -236,6 +240,10 @@ export default function useSlowQueryTableController(
     }
   }
 
+  const { saveClickedItemIndex, getClickedItemIndex } = useCacheItemIndex(
+    cacheMgr
+  )
+
   return {
     queryOptions,
     setQueryOptions,
@@ -255,5 +263,8 @@ export default function useSlowQueryTableController(
 
     downloading,
     downloadCSV,
+
+    saveClickedItemIndex,
+    getClickedItemIndex,
   }
 }

--- a/ui/lib/apps/Statement/components/StatementsTable.tsx
+++ b/ui/lib/apps/Statement/components/StatementsTable.tsx
@@ -22,11 +22,15 @@ export default function StatementsTable({ controller, ...restPrpos }: Props) {
     errors,
     tableColumns,
     visibleColumnKeys,
+
+    getClickedItemIndex,
+    saveClickedItemIndex,
   } = controller
 
   const navigate = useNavigate()
   const handleRowClick = usePersistFn(
-    (rec, _idx, ev: React.MouseEvent<HTMLElement>) => {
+    (rec, idx, ev: React.MouseEvent<HTMLElement>) => {
+      saveClickedItemIndex(idx)
       const qs = DetailPage.buildQuery({
         digest: rec.digest,
         schema: rec.schema_name,
@@ -52,6 +56,7 @@ export default function StatementsTable({ controller, ...restPrpos }: Props) {
       visibleColumnKeys={visibleColumnKeys}
       onRowClicked={handleRowClick}
       getKey={getKey}
+      initialFocusedIndex={getClickedItemIndex()}
     />
   )
 }

--- a/ui/lib/apps/Statement/components/StatementsTable.tsx
+++ b/ui/lib/apps/Statement/components/StatementsTable.tsx
@@ -1,6 +1,7 @@
 import { usePersistFn } from 'ahooks'
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { IDetailsList } from 'office-ui-fabric-react/lib/DetailsList'
 
 import openLink from '@lib/utils/openLink'
 import { CardTable, ICardTableProps } from '@lib/components'
@@ -43,6 +44,11 @@ export default function StatementsTable({ controller, ...restPrpos }: Props) {
 
   const getKey = useCallback((row) => `${row.digest}_${row.schema_name}`, [])
 
+  const tableRef = useRef<IDetailsList>(null)
+  useEffect(() => {
+    tableRef.current?.scrollToIndex(getClickedItemIndex())
+  }, [getClickedItemIndex])
+
   return (
     <CardTable
       {...restPrpos}
@@ -56,7 +62,8 @@ export default function StatementsTable({ controller, ...restPrpos }: Props) {
       visibleColumnKeys={visibleColumnKeys}
       onRowClicked={handleRowClick}
       getKey={getKey}
-      initialFocusedIndex={getClickedItemIndex()}
+      componentRef={tableRef}
+      clickedRowIndex={getClickedItemIndex()}
     />
   )
 }

--- a/ui/lib/apps/Statement/components/StatementsTable.tsx
+++ b/ui/lib/apps/Statement/components/StatementsTable.tsx
@@ -1,7 +1,6 @@
 import { usePersistFn } from 'ahooks'
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { IDetailsList } from 'office-ui-fabric-react/lib/DetailsList'
 
 import openLink from '@lib/utils/openLink'
 import { CardTable, ICardTableProps } from '@lib/components'
@@ -44,11 +43,6 @@ export default function StatementsTable({ controller, ...restPrpos }: Props) {
 
   const getKey = useCallback((row) => `${row.digest}_${row.schema_name}`, [])
 
-  const tableRef = useRef<IDetailsList>(null)
-  useEffect(() => {
-    tableRef.current?.scrollToIndex(getClickedItemIndex())
-  }, [getClickedItemIndex])
-
   return (
     <CardTable
       {...restPrpos}
@@ -62,7 +56,6 @@ export default function StatementsTable({ controller, ...restPrpos }: Props) {
       visibleColumnKeys={visibleColumnKeys}
       onRowClicked={handleRowClick}
       getKey={getKey}
-      componentRef={tableRef}
       clickedRowIndex={getClickedItemIndex()}
     />
   )

--- a/ui/lib/apps/Statement/index.tsx
+++ b/ui/lib/apps/Statement/index.tsx
@@ -7,7 +7,7 @@ import useCache, { CacheContext } from '@lib/utils/useCache'
 import { Detail, List } from './pages'
 
 export default function () {
-  const statementCacheMgr = useCache()
+  const statementCacheMgr = useCache(2)
 
   return (
     <Root>

--- a/ui/lib/apps/Statement/utils/useStatementTableController.ts
+++ b/ui/lib/apps/Statement/utils/useStatementTableController.ts
@@ -232,7 +232,6 @@ export default function useStatementTableController(
           )
         setStatements(res?.data || [])
         cacheMgr?.set(cacheKey, res?.data || [])
-        saveClickedItemIndex(-1)
         setErrors([])
       } catch (e) {
         setErrors((prev) => prev.concat(e))

--- a/ui/lib/apps/Statement/utils/useStatementTableController.ts
+++ b/ui/lib/apps/Statement/utils/useStatementTableController.ts
@@ -71,6 +71,9 @@ export interface IStatementTableController {
 
   downloadCSV: () => Promise<void>
   downloading: boolean
+
+  saveClickedItemIndex: (idx: number) => void
+  getClickedItemIndex: () => number
 }
 
 export default function useStatementTableController(
@@ -268,6 +271,14 @@ export default function useStatementTableController(
     }
   }
 
+  const CLICKED_ITEM_INDEX = 'clicked_item_index'
+  function saveClickedItemIndex(idx: number) {
+    cacheMgr?.set(CLICKED_ITEM_INDEX, idx)
+  }
+  function getClickedItemIndex(): number {
+    return cacheMgr?.get(CLICKED_ITEM_INDEX) || -1
+  }
+
   return {
     queryOptions,
     setQueryOptions,
@@ -290,5 +301,8 @@ export default function useStatementTableController(
 
     downloadCSV,
     downloading,
+
+    saveClickedItemIndex,
+    getClickedItemIndex,
   }
 }

--- a/ui/lib/apps/Statement/utils/useStatementTableController.ts
+++ b/ui/lib/apps/Statement/utils/useStatementTableController.ts
@@ -8,9 +8,10 @@ import client, {
   StatementTimeRange,
 } from '@lib/client'
 import { IColumnKeys, stringifyTimeRange } from '@lib/components'
-import useOrderState, { IOrderOptions } from '@lib/utils/useOrderState'
 import { getSelectedFields } from '@lib/utils/tableColumnFactory'
 import { CacheMgr } from '@lib/utils/useCache'
+import useOrderState, { IOrderOptions } from '@lib/utils/useOrderState'
+import useCacheItemIndex from '@lib/utils/useCacheItemIndex'
 
 import {
   calcValidStatementTimeRange,
@@ -271,13 +272,9 @@ export default function useStatementTableController(
     }
   }
 
-  const CLICKED_ITEM_INDEX = 'clicked_item_index'
-  function saveClickedItemIndex(idx: number) {
-    cacheMgr?.set(CLICKED_ITEM_INDEX, idx)
-  }
-  function getClickedItemIndex(): number {
-    return cacheMgr?.get(CLICKED_ITEM_INDEX) || -1
-  }
+  const { saveClickedItemIndex, getClickedItemIndex } = useCacheItemIndex(
+    cacheMgr
+  )
 
   return {
     queryOptions,

--- a/ui/lib/apps/Statement/utils/useStatementTableController.ts
+++ b/ui/lib/apps/Statement/utils/useStatementTableController.ts
@@ -232,6 +232,7 @@ export default function useStatementTableController(
           )
         setStatements(res?.data || [])
         cacheMgr?.set(cacheKey, res?.data || [])
+        saveClickedItemIndex(-1)
         setErrors([])
       } catch (e) {
         setErrors((prev) => prev.concat(e))

--- a/ui/lib/components/CardTable/index.module.less
+++ b/ui/lib/components/CardTable/index.module.less
@@ -52,7 +52,7 @@
 }
 
 .highlightRow {
-  border: 2px solid;
+  border: 1px solid;
 }
 
 .cardTableContent {

--- a/ui/lib/components/CardTable/index.module.less
+++ b/ui/lib/components/CardTable/index.module.less
@@ -51,6 +51,10 @@
   cursor: pointer;
 }
 
+.highlightRow {
+  border: 2px solid;
+}
+
 .cardTableContent {
   margin-left: -@padding-page;
   margin-right: -@padding-page;

--- a/ui/lib/components/CardTable/index.tsx
+++ b/ui/lib/components/CardTable/index.tsx
@@ -115,7 +115,7 @@ function useRenderClickableRow(onRowClicked, clickedRowIdx) {
         </div>
       )
     },
-    [onRowClicked]
+    [onRowClicked, clickedRowIdx]
   )
 }
 

--- a/ui/lib/components/CardTable/index.tsx
+++ b/ui/lib/components/CardTable/index.tsx
@@ -96,6 +96,7 @@ export interface ICardTableProps extends IDetailsListProps {
     itemIndex: number,
     ev: React.MouseEvent<HTMLElement>
   ) => void
+  clickedRowIndex?: number
 }
 
 function useRenderClickableRow(onRowClicked, clickedRowIdx) {
@@ -148,14 +149,14 @@ export default function CardTable(props: ICardTableProps) {
     desc = true,
     onChangeOrder,
     onRowClicked,
+    clickedRowIndex,
     columns,
     items,
-    initialFocusedIndex,
     ...restProps
   } = props
   const renderClickableRow = useRenderClickableRow(
     onRowClicked,
-    initialFocusedIndex || -1
+    clickedRowIndex || -1
   )
 
   const onColumnClick = usePersistFn(
@@ -240,7 +241,6 @@ export default function CardTable(props: ICardTableProps) {
             onRenderRow={onRowClicked ? renderClickableRow : undefined}
             columns={finalColumns}
             items={finalItems}
-            initialFocusedIndex={initialFocusedIndex}
             {...restProps}
           />
         </div>

--- a/ui/lib/components/CardTable/index.tsx
+++ b/ui/lib/components/CardTable/index.tsx
@@ -98,7 +98,7 @@ export interface ICardTableProps extends IDetailsListProps {
   ) => void
 }
 
-function useRenderClickableRow(onRowClicked) {
+function useRenderClickableRow(onRowClicked, clickedRowIdx) {
   return useCallback(
     (props, defaultRender) => {
       if (!props) {
@@ -106,7 +106,9 @@ function useRenderClickableRow(onRowClicked) {
       }
       return (
         <div
-          className={styles.clickableTableRow}
+          className={cx(styles.clickableTableRow, {
+            [styles.highlightRow]: clickedRowIdx === props.itemIndex,
+          })}
           onClick={(ev) => onRowClicked?.(props.item, props.itemIndex, ev)}
         >
           {defaultRender!(props)}
@@ -148,9 +150,13 @@ export default function CardTable(props: ICardTableProps) {
     onRowClicked,
     columns,
     items,
+    initialFocusedIndex,
     ...restProps
   } = props
-  const renderClickableRow = useRenderClickableRow(onRowClicked)
+  const renderClickableRow = useRenderClickableRow(
+    onRowClicked,
+    initialFocusedIndex || -1
+  )
 
   const onColumnClick = usePersistFn(
     (_ev: React.MouseEvent<HTMLElement>, column: IColumn) => {
@@ -234,6 +240,7 @@ export default function CardTable(props: ICardTableProps) {
             onRenderRow={onRowClicked ? renderClickableRow : undefined}
             columns={finalColumns}
             items={finalItems}
+            initialFocusedIndex={initialFocusedIndex}
             {...restProps}
           />
         </div>

--- a/ui/lib/components/CardTable/index.tsx
+++ b/ui/lib/components/CardTable/index.tsx
@@ -7,11 +7,12 @@ import {
   DetailsList,
   DetailsListLayoutMode,
   IColumn,
+  IDetailsList,
   IDetailsListProps,
   SelectionMode,
 } from 'office-ui-fabric-react/lib/DetailsList'
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky'
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import AnimatedSkeleton from '../AnimatedSkeleton'
 import Card from '../Card'
@@ -214,6 +215,13 @@ export default function CardTable(props: ICardTableProps) {
     return newItems
   }, [visibleItemsCount, items, orderBy, finalColumns])
 
+  const tableRef = useRef<IDetailsList>(null)
+  useEffect(() => {
+    if ((clickedRowIndex ?? -1) > 0) {
+      tableRef.current?.scrollToIndex(clickedRowIndex!)
+    }
+  })
+
   return (
     <Card
       title={title}
@@ -241,6 +249,7 @@ export default function CardTable(props: ICardTableProps) {
             onRenderRow={onRowClicked ? renderClickableRow : undefined}
             columns={finalColumns}
             items={finalItems}
+            componentRef={tableRef}
             {...restProps}
           />
         </div>

--- a/ui/lib/utils/useCacheItemIndex.ts
+++ b/ui/lib/utils/useCacheItemIndex.ts
@@ -1,0 +1,16 @@
+import { CacheMgr } from './useCache'
+
+export default function useCacheItemIndex(cacheMgr: CacheMgr | null) {
+  const CLICKED_ITEM_INDEX = 'clicked_item_index'
+  function saveClickedItemIndex(idx: number) {
+    cacheMgr?.set(CLICKED_ITEM_INDEX, idx)
+  }
+  function getClickedItemIndex(): number {
+    return cacheMgr?.get(CLICKED_ITEM_INDEX) || -1
+  }
+
+  return {
+    saveClickedItemIndex,
+    getClickedItemIndex,
+  }
+}


### PR DESCRIPTION
Related PR: #828 

What did:

- Remember the last coarse scrolled position (in fact the clicked row) in the statements table, restore the position when coming back from the detail page

Effect:

![5](https://user-images.githubusercontent.com/1284531/103743423-1626d880-5037-11eb-82d9-94ec58a0e041.gif)

![image](https://user-images.githubusercontent.com/1284531/103744807-5be4a080-5039-11eb-8808-cad94c31e0d0.png)

How it implemented:

Because I didn't find a good way to remember and recover the exactly scrolled position for the statements table, I found the fluent UI DetailsList has a [initialFocusedIndex](https://developer.microsoft.com/en-us/fluentui#/controls/web/detailslist) props that can make the list scroll to the target row when initializing. So we can remember the row index when clicking it. (Later found the initialFocusedIndex doesn't work well when the index is large, it needs the item is already rendered before scrolling to. Replace it with `scrollToIndex()` method and works well.)

When coming back from the detail page, the clicked row may not be scrolled to the exact position when leave, it may scroll to the top, middle, or bottom of the list, but we can see it on the screen. 

To make the user can get the last clicked row as quickly as possible, we can add a highlight effect for it, for example, an extra border.

Not sure whether this solution is acceptable, if it does, I will apply it for the slow query table.



