### PR TITLE
Feat/add share session unit

### DIFF
--- a/pkg/apiserver/utils/auth.go
+++ b/pkg/apiserver/utils/auth.go
@@ -40,7 +40,7 @@ const (
 	SessionUserKey = "user"
 
 	// Max permitted lifetime of a shared session.
-	MaxSessionShareExpiry = time.Hour * 24
+	MaxSessionShareExpiry = time.Hour * 24 * 30
 )
 
 // The secret is always regenerated each time starting TiDB Dashboard.

--- a/ui/lib/apps/UserProfile/index.tsx
+++ b/ui/lib/apps/UserProfile/index.tsx
@@ -42,7 +42,19 @@ import { getValueFormat } from '@baurine/grafana-value-formats'
 import ReactMarkdown from 'react-markdown'
 
 const DEFAULT_FORM_ITEM_STYLE = { width: 200 }
-const SHARE_SESSION_EXPIRY_HOURS = [0.25, 0.5, 1, 2, 3, 6, 12, 24]
+const SHARE_SESSION_EXPIRY_HOURS = [
+  0.25,
+  0.5,
+  1,
+  2,
+  3,
+  6,
+  12,
+  24,
+  24 * 3,
+  24 * 7,
+  24 * 30,
+]
 
 function ShareSessionButton() {
   const { t } = useTranslation()


### PR DESCRIPTION
close #847

- Support the longer expired duration,  3 days, 7 days, and 30 days.