### PR TITLE
Feature: Display CPU arch

### DIFF
--- a/pkg/apiserver/clusterinfo/hostinfo/cluster_hardware.go
+++ b/pkg/apiserver/clusterinfo/hostinfo/cluster_hardware.go
@@ -25,8 +25,9 @@ import (
 
 // Used to deserialize from JSON_VALUE
 type clusterHardwareCPUInfoModel struct {
-	LogicalCores  int `json:"cpu-logical-cores,string"`
-	PhysicalCores int `json:"cpu-physical-cores,string"`
+	Arch 		  string `json:"cpu-arch,string"`
+	LogicalCores  int	 `json:"cpu-logical-cores,string"`
+	PhysicalCores int	 `json:"cpu-physical-cores,string"`
 }
 
 // Used to deserialize from JSON_VALUE
@@ -75,6 +76,7 @@ func FillFromClusterHardwareTable(db *gorm.DB, m InfoMap) error {
 				continue
 			}
 			m[hostname].CPUInfo = &CPUInfo{
+				arch:v.Arch,
 				LogicalCores:  v.LogicalCores,
 				PhysicalCores: v.PhysicalCores,
 			}

--- a/pkg/apiserver/clusterinfo/hostinfo/cluster_hardware.go
+++ b/pkg/apiserver/clusterinfo/hostinfo/cluster_hardware.go
@@ -25,9 +25,9 @@ import (
 
 // Used to deserialize from JSON_VALUE
 type clusterHardwareCPUInfoModel struct {
-	Arch 		  string `json:"cpu-arch,string"`
-	LogicalCores  int	 `json:"cpu-logical-cores,string"`
-	PhysicalCores int	 `json:"cpu-physical-cores,string"`
+	Arch          string `json:"cpu-arch"`
+	LogicalCores  int    `json:"cpu-logical-cores,string"`
+	PhysicalCores int    `json:"cpu-physical-cores,string"`
 }
 
 // Used to deserialize from JSON_VALUE
@@ -76,7 +76,7 @@ func FillFromClusterHardwareTable(db *gorm.DB, m InfoMap) error {
 				continue
 			}
 			m[hostname].CPUInfo = &CPUInfo{
-				arch:v.Arch,
+				Arch:          v.Arch,
 				LogicalCores:  v.LogicalCores,
 				PhysicalCores: v.PhysicalCores,
 			}

--- a/pkg/apiserver/clusterinfo/hostinfo/hostinfo.go
+++ b/pkg/apiserver/clusterinfo/hostinfo/hostinfo.go
@@ -26,9 +26,9 @@ type MemoryUsageInfo struct {
 }
 
 type CPUInfo struct {
-	Arch		  string	`json:"arch"`
-	LogicalCores  int 		`json:"logical_cores"`
-	PhysicalCores int 		`json:"physical_cores"`
+	Arch          string `json:"arch"`
+	LogicalCores  int    `json:"logical_cores"`
+	PhysicalCores int    `json:"physical_cores"`
 }
 
 type PartitionInfo struct {

--- a/pkg/apiserver/clusterinfo/hostinfo/hostinfo.go
+++ b/pkg/apiserver/clusterinfo/hostinfo/hostinfo.go
@@ -26,9 +26,9 @@ type MemoryUsageInfo struct {
 }
 
 type CPUInfo struct {
-	LogicalCores  int `json:"logical_cores"`
-	PhysicalCores int `json:"physical_cores"`
-	// TODO: Support arch.
+	Arch		  string	`json:"arch"`
+	LogicalCores  int 		`json:"logical_cores"`
+	PhysicalCores int 		`json:"physical_cores"`
 }
 
 type PartitionInfo struct {

--- a/ui/lib/apps/ClusterInfo/components/HostTable.tsx
+++ b/ui/lib/apps/ClusterInfo/components/HostTable.tsx
@@ -111,8 +111,8 @@ Logical Cores:  ${c.logical_cores}`
           if (!c) {
             return
           }
-          if (c.arch==="") {
-            c.arch="Unknown"
+          if (c.arch === '') {
+            c.arch = 'Unknown'
           }
           const tooltipContent = `CPU Arch:${c.arch}`
           return (

--- a/ui/lib/apps/ClusterInfo/components/HostTable.tsx
+++ b/ui/lib/apps/ClusterInfo/components/HostTable.tsx
@@ -102,6 +102,24 @@ Logical Cores:  ${c.logical_cores}`
         },
       },
       {
+        name: t('cluster_info.list.host_table.columns.cpu_arch'),
+        key: 'cpu',
+        minWidth: 100,
+        maxWidth: 150,
+        onRender: (row: IExpandedHostItem) => {
+          const { cpu_info: c } = row
+          if (!c) {
+            return
+          }
+          const tooltipContent = `CPU Arch:${c.arch}`
+          return (
+            <Tooltip title={<Pre>{tooltipContent.trim()}</Pre>}>
+              <span>{`${c.arch}`}</span>
+            </Tooltip>
+          )
+        },
+      },
+      {
         name: t('cluster_info.list.host_table.columns.cpu_usage'),
         key: 'cpu_usage',
         minWidth: 100,

--- a/ui/lib/apps/ClusterInfo/components/HostTable.tsx
+++ b/ui/lib/apps/ClusterInfo/components/HostTable.tsx
@@ -111,6 +111,9 @@ Logical Cores:  ${c.logical_cores}`
           if (!c) {
             return
           }
+          if (c.arch==="") {
+            c.arch="Unknown"
+          }
           const tooltipContent = `CPU Arch:${c.arch}`
           return (
             <Tooltip title={<Pre>{tooltipContent.trim()}</Pre>}>

--- a/ui/lib/apps/ClusterInfo/components/HostTable.tsx
+++ b/ui/lib/apps/ClusterInfo/components/HostTable.tsx
@@ -103,23 +103,15 @@ Logical Cores:  ${c.logical_cores}`
       },
       {
         name: t('cluster_info.list.host_table.columns.cpu_arch'),
-        key: 'cpu',
-        minWidth: 100,
-        maxWidth: 150,
+        key: 'cpu-arch',
+        minWidth: 60,
+        maxWidth: 100,
         onRender: (row: IExpandedHostItem) => {
           const { cpu_info: c } = row
-          if (!c) {
-            return
+          if (!c || !c.arch) {
+            return <span>{'Unknow'}</span>
           }
-          if (c.arch === '') {
-            c.arch = 'Unknown'
-          }
-          const tooltipContent = `CPU Arch:${c.arch}`
-          return (
-            <Tooltip title={<Pre>{tooltipContent.trim()}</Pre>}>
-              <span>{`${c.arch}`}</span>
-            </Tooltip>
-          )
+          return <span>{`${c.arch}`}</span>
         },
       },
       {

--- a/ui/lib/apps/ClusterInfo/translations/en.yaml
+++ b/ui/lib/apps/ClusterInfo/translations/en.yaml
@@ -19,6 +19,7 @@ cluster_info:
       columns:
         host: Host Address
         cpu: CPU
+        cpu_arch: CPU Arch
         cpu_usage: CPU Usage
         memory: Memory
         memory_usage: Memory Usage

--- a/ui/lib/apps/ClusterInfo/translations/zh.yaml
+++ b/ui/lib/apps/ClusterInfo/translations/zh.yaml
@@ -19,6 +19,7 @@ cluster_info:
       columns:
         host: 主机地址
         cpu: CPU
+        cpu_arch: CPU 架构
         cpu_usage: CPU 使用率
         memory: 物理内存
         memory_usage: 内存使用率


### PR DESCRIPTION
Signed-off-by: Max-Cheng aaron9shire@gmail.com

What's Changed:

- Backend
  - CPUinfo
- Frontend
  - add new column specifically for the CPU Arch
  - i18n
 
<img width="1440" alt="截屏2021-02-22 上午12 30 14" src="https://user-images.githubusercontent.com/21263915/108631723-36570d80-74a6-11eb-8e5c-afc778e39525.png">
<img width="1440" alt="截屏2021-02-22 上午12 32 56" src="https://user-images.githubusercontent.com/21263915/108631735-453dc000-74a6-11eb-9067-06c1abafec92.png">
<img width="1053" alt="截屏2021-02-22 上午12 33 05" src="https://user-images.githubusercontent.com/21263915/108631742-4a027400-74a6-11eb-8487-b32fe6a5b8aa.png">
<img width="1082" alt="截屏2021-02-22 上午12 33 00" src="https://user-images.githubusercontent.com/21263915/108631746-4cfd6480-74a6-11eb-8aa1-a0f09450e50a.png">

