### PR TITLE
Redirect root path to UI handler at /dashboard

### DIFF
--- a/cmd/tidb-dashboard/main.go
+++ b/cmd/tidb-dashboard/main.go
@@ -192,6 +192,7 @@ func main() {
 
 	mux := http.DefaultServeMux
 	uiHandler := http.StripPrefix(strings.TrimRight(config.UIPathPrefix, "/"), uiserver.Handler(assets))
+	mux.Handle("/", http.RedirectHandler(config.UIPathPrefix, http.StatusFound))
 	mux.Handle(config.UIPathPrefix, uiHandler)
 	mux.Handle(config.APIPathPrefix, apiserver.Handler(s))
 	mux.Handle(config.SwaggerPathPrefix, swaggerserver.Handler())


### PR DESCRIPTION
This change proposes sending the client an HTTP 302 to `/dashboard` when the root path `/` is requested. This is a convenience feature useful for standalone/non-embedded TiDB dashboard deployments.