### PR TITLE
fix(ttlcache): goroutine leak

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/ReneKroon/ttlcache/v2"
 	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
@@ -66,7 +65,6 @@ var (
 type Service struct {
 	app    *fx.App
 	status *utils.ServiceStatus
-	cache  *ttlcache.Cache
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -110,7 +108,6 @@ func (s *Service) Start(ctx context.Context) error {
 		fx.Logger(utils.NewFxPrinter()),
 		fx.Provide(
 			newAPIHandlerEngine,
-			newTTLCache,
 			s.provideLocals,
 			dbstore.NewDBStore,
 			httpc.NewHTTPClient,
@@ -136,7 +133,7 @@ func (s *Service) Start(ctx context.Context) error {
 		profiling.Module,
 		statement.Module,
 		slowquery.Module,
-		fx.Populate(&s.apiHandlerEngine, &s.cache),
+		fx.Populate(&s.apiHandlerEngine),
 		fx.Invoke(
 			user.RegisterRouter,
 			info.RegisterRouter,
@@ -167,12 +164,10 @@ func (s *Service) Start(ctx context.Context) error {
 
 func (s *Service) cleanAfterError() {
 	s.cancel()
-	s.cache.Close()
 
 	// drop
 	s.app = nil
 	s.apiHandlerEngine = nil
-	s.cache = nil
 	s.ctx = nil
 	s.cancel = nil
 }
@@ -183,13 +178,11 @@ func (s *Service) Stop(ctx context.Context) error {
 	}
 
 	s.cancel()
-	s.cache.Close()
 	err := s.app.Stop(ctx)
 
 	// drop
 	s.app = nil
 	s.apiHandlerEngine = nil
-	s.cache = nil
 	s.ctx = nil
 	s.cancel = nil
 
@@ -218,12 +211,6 @@ func newAPIHandlerEngine() (apiHandlerEngine *gin.Engine, endpoint *gin.RouterGr
 	endpoint = apiHandlerEngine.Group("/dashboard/api")
 
 	return
-}
-
-func newTTLCache() *ttlcache.Cache {
-	cache := ttlcache.NewCache()
-	cache.SkipTTLExtensionOnHit(true)
-	return cache
 }
 
 var StoppedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/utils/sys_schema.go
+++ b/pkg/utils/sys_schema.go
@@ -29,11 +29,9 @@ type SysSchema struct {
 	cache *ttlcache.Cache
 }
 
-func NewSysSchema() *SysSchema {
-	c := ttlcache.NewCache()
-	c.SkipTTLExtensionOnHit(true)
+func NewSysSchema(cache *ttlcache.Cache) *SysSchema {
 	return &SysSchema{
-		cache: c,
+		cache: cache,
 	}
 }
 

--- a/pkg/utils/sys_schema.go
+++ b/pkg/utils/sys_schema.go
@@ -14,11 +14,13 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/ReneKroon/ttlcache/v2"
 	"github.com/jinzhu/gorm"
+	"go.uber.org/fx"
 )
 
 const (
@@ -29,9 +31,16 @@ type SysSchema struct {
 	cache *ttlcache.Cache
 }
 
-func NewSysSchema() *SysSchema {
+func NewSysSchema(lc fx.Lifecycle) *SysSchema {
 	c := ttlcache.NewCache()
 	c.SkipTTLExtensionOnHit(true)
+
+	lc.Append(fx.Hook{
+		OnStop: func(ctx context.Context) error {
+			return c.Close()
+		},
+	})
+
 	return &SysSchema{
 		cache: c,
 	}

--- a/pkg/utils/sys_schema.go
+++ b/pkg/utils/sys_schema.go
@@ -29,9 +29,11 @@ type SysSchema struct {
 	cache *ttlcache.Cache
 }
 
-func NewSysSchema(cache *ttlcache.Cache) *SysSchema {
+func NewSysSchema() *SysSchema {
+	c := ttlcache.NewCache()
+	c.SkipTTLExtensionOnHit(true)
 	return &SysSchema{
-		cache: cache,
+		cache: c,
 	}
 }
 


### PR DESCRIPTION
Related: [pd/pull/3604](https://github.com/tikv/pd/pull/3604)

Cleanup ttl cache at end of lifecycle.