### PR TITLE
tidb: forwarder only uses tidb whose status is Up

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -293,7 +293,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -349,7 +348,6 @@ go.uber.org/dig v1.8.0 h1:1rR6hnL/bu1EVcjnRDN5kx1vbIjEJDTGhSQ2B3ddpcI=
 go.uber.org/dig v1.8.0/go.mod h1:X34SnWGr8Fyla9zQNO2GSO2D+TIuqB14OS8JhYocIyw=
 go.uber.org/fx v1.10.0 h1:S2K/H8oNied0Je/mLKdWzEWKZfv9jtxSDm8CnwK+5Fg=
 go.uber.org/fx v1.10.0/go.mod h1:vLRicqpG/qQEzno4SYU86iCwfT95EZza+Eba0ItuxqY=
-go.uber.org/goleak v0.10.0 h1:G3eWbSNIskeRqtsN/1uI5B+eP73y3JUuBsv9AZjehb4=
 go.uber.org/goleak v0.10.0/go.mod h1:VCZuO8V8mFPlL0F5J5GK1rtHV3DrFcQ1R8ryq7FK0aI=
 go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
@@ -373,7 +371,6 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72 h1:+ELyKg6m8UBf0nPFSqD0mi7zUfwPyXo23HNjMnXPz7w=
 golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -413,7 +410,6 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
@@ -435,7 +431,6 @@ golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/pkg/keyvisual/decorator/tidb_requests.go
+++ b/pkg/keyvisual/decorator/tidb_requests.go
@@ -45,12 +45,20 @@ func (s *tidbLabelStrategy) updateMap(ctx context.Context) {
 	resp, err := s.EtcdClient.Get(ectx, schemaVersionPath)
 	cancel()
 	if err != nil || len(resp.Kvs) != 1 {
-		log.Warn("failed to get tidb schema version", zap.Error(err))
+		if s.SchemaVersion != -1 {
+			log.Warn("failed to get tidb schema version", zap.Error(err))
+		} else {
+			log.Debug("failed to get tidb schema version, maybe not a TiDB cluster", zap.Error(err))
+		}
 		return
 	}
 	schemaVersion, err := strconv.ParseInt(string(resp.Kvs[0].Value), 10, 64)
 	if err != nil {
-		log.Warn("failed to get tidb schema version", zap.Error(err))
+		if s.SchemaVersion != -1 {
+			log.Warn("failed to get tidb schema version", zap.Error(err))
+		} else {
+			log.Debug("failed to get tidb schema version, maybe not a TiDB cluster", zap.Error(err))
+		}
 		return
 	}
 	if schemaVersion == s.SchemaVersion {

--- a/pkg/tidb/forwarder.go
+++ b/pkg/tidb/forwarder.go
@@ -101,8 +101,10 @@ func (f *Forwarder) pollingForTiDB() {
 			statusEndpoints := make(map[string]struct{}, len(allTiDB))
 			tidbEndpoints := make(map[string]struct{}, len(allTiDB))
 			for _, server := range allTiDB {
-				tidbEndpoints[fmt.Sprintf("%s:%d", server.IP, server.Port)] = struct{}{}
-				statusEndpoints[fmt.Sprintf("%s:%d", server.IP, server.StatusPort)] = struct{}{}
+				if server.Status == topology.ComponentStatusUp {
+					tidbEndpoints[fmt.Sprintf("%s:%d", server.IP, server.Port)] = struct{}{}
+					statusEndpoints[fmt.Sprintf("%s:%d", server.IP, server.StatusPort)] = struct{}{}
+				}
 			}
 			f.sqlProxy.updateRemotes(tidbEndpoints)
 			f.statusProxy.updateRemotes(statusEndpoints)

--- a/pkg/utils/topology/tidb.go
+++ b/pkg/utils/topology/tidb.go
@@ -71,7 +71,7 @@ func FetchTiDBTopology(ctx context.Context, etcdClient *clientv3.Client) ([]TiDB
 			if err == nil {
 				nodesAlive[keyParts[0]] = struct{}{}
 				if !alive {
-					log.Debug("Alive of TiDB has expired, maybe time is incorrect",
+					log.Warn("Alive of TiDB has expired, maybe local time in different hosts are not synchronized",
 						zap.String("key", key),
 						zap.String("value", string(kv.Value)))
 				}

--- a/pkg/utils/topology/tidb.go
+++ b/pkg/utils/topology/tidb.go
@@ -39,8 +39,8 @@ func FetchTiDBTopology(ctx context.Context, etcdClient *clientv3.Client) ([]TiDB
 		return nil, ErrEtcdRequestFailed.Wrap(err, "failed to get key %s from PD etcd", tidbTopologyKeyPrefix)
 	}
 
-	nodesAlive := map[string]bool{}
-	nodesInfo := map[string]*TiDBInfo{}
+	nodesAlive := make(map[string]struct{}, len(resp.Kvs))
+	nodesInfo := make(map[string]*TiDBInfo, len(resp.Kvs))
 
 	for _, kv := range resp.Kvs {
 		key := string(kv.Key)
@@ -69,7 +69,12 @@ func FetchTiDBTopology(ctx context.Context, etcdClient *clientv3.Client) ([]TiDB
 		case "ttl":
 			alive, err := parseTiDBAliveness(kv.Value)
 			if err == nil {
-				nodesAlive[keyParts[0]] = alive
+				nodesAlive[keyParts[0]] = struct{}{}
+				if !alive {
+					log.Debug("Alive of TiDB has expired, maybe time is incorrect",
+						zap.String("key", key),
+						zap.String("value", string(kv.Value)))
+				}
 			} else {
 				log.Warn("Ignored invalid TiDB topology TTL entry",
 					zap.String("key", key),
@@ -82,10 +87,8 @@ func FetchTiDBTopology(ctx context.Context, etcdClient *clientv3.Client) ([]TiDB
 	nodes := make([]TiDBInfo, 0)
 
 	for addr, info := range nodesInfo {
-		if alive, ok := nodesAlive[addr]; ok {
-			if alive {
-				info.Status = ComponentStatusUp
-			}
+		if _, ok := nodesAlive[addr]; ok {
+			info.Status = ComponentStatusUp
 		}
 		nodes = append(nodes, *info)
 	}


### PR DESCRIPTION
close [tikv/pd#3612](https://github.com/tikv/pd/issues/3612)

* tidb: forwarder only uses tidb whose status is Up
  * reduce warn log `fail to recv activity from remote, stay inactive and wait to next checking round`