### PR TITLE
fix(ui): setState after unmount in `useBatchClientRequest`

### DIFF
--- a/ui/lib/utils/useClientRequest.ts
+++ b/ui/lib/utils/useClientRequest.ts
@@ -171,10 +171,12 @@ export function useBatchClientRequest<T>(
 
     const p = reqFactories.map((_, idx) => sendRequestEach(idx))
     await Promise.all(p)
-    setState((s) => ({
-      ...s,
-      isLoading: false,
-    }))
+    if (mounted.current) {
+      setState((s) => ({
+        ...s,
+        isLoading: false,
+      }))
+    }
 
     cancelTokenSource.current = null
 


### PR DESCRIPTION
Fix no-op warning comes from `useBatchClientRequest`.

![image](https://user-images.githubusercontent.com/11549583/117258534-a78c4700-ae7f-11eb-8482-3aad54e49c89.png)
