### PR TITLE
tweak: slow query & stmt db select placeholder

### DIFF
--- a/ui/lib/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/lib/apps/SlowQuery/pages/List/index.tsx
@@ -74,10 +74,7 @@ function List() {
   } = controller
 
   function exportCSV() {
-    const hide = message.loading(
-      t('statement.pages.overview.toolbar.exporting') + '...',
-      0
-    )
+    const hide = message.loading(t('slow_query.toolbar.exporting') + '...', 0)
     downloadCSV().finally(hide)
   }
 
@@ -93,8 +90,8 @@ function List() {
     <Menu onClick={menuItemClick}>
       <Menu.Item key="export" disabled={downloading} icon={<ExportOutlined />}>
         {downloading
-          ? t('statement.pages.overview.toolbar.exporting')
-          : t('statement.pages.overview.toolbar.export')}
+          ? t('slow_query.toolbar.exporting')
+          : t('slow_query.toolbar.export')}
       </Menu.Item>
     </Menu>
   )
@@ -114,13 +111,9 @@ function List() {
               }
             />
             <MultiSelect.Plain
-              placeholder={t(
-                'statement.pages.overview.toolbar.schemas.placeholder'
-              )}
-              selectedValueTransKey="statement.pages.overview.toolbar.schemas.selected"
-              columnTitle={t(
-                'statement.pages.overview.toolbar.schemas.columnTitle'
-              )}
+              placeholder={t('slow_query.toolbar.schemas.placeholder')}
+              selectedValueTransKey="slow_query.toolbar.schemas.selected"
+              columnTitle={t('slow_query.toolbar.schemas.columnTitle')}
               value={queryOptions.schemas}
               style={{ width: 150 }}
               onChange={(schemas) =>
@@ -162,14 +155,12 @@ function List() {
                     checked={showFullSQL}
                     onChange={(e) => setShowFullSQL(e.target.checked)}
                   >
-                    {t(
-                      'statement.pages.overview.toolbar.select_columns.show_full_sql'
-                    )}
+                    {t('slow_query.toolbar.select_columns.show_full_sql')}
                   </Checkbox>
                 }
               />
             )}
-            <Tooltip title={t('statement.pages.overview.toolbar.refresh')}>
+            <Tooltip title={t('slow_query.toolbar.refresh')}>
               {loadingSlowQueries ? (
                 <LoadingOutlined />
               ) : (

--- a/ui/lib/apps/SlowQuery/translations/en.yaml
+++ b/ui/lib/apps/SlowQuery/translations/en.yaml
@@ -123,7 +123,7 @@ slow_query:
       txn: Transaction
   toolbar:
     schemas:
-      placeholder: All Databases
+      placeholder: Execution Databases
       selected: '{{ n }} Databases'
       columnTitle: Database Name
     select_columns:

--- a/ui/lib/apps/SlowQuery/translations/en.yaml
+++ b/ui/lib/apps/SlowQuery/translations/en.yaml
@@ -123,9 +123,9 @@ slow_query:
       txn: Transaction
   toolbar:
     schemas:
-      placeholder: Execution Databases
+      placeholder: All Databases
       selected: '{{ n }} Databases'
-      columnTitle: Database Name
+      columnTitle: Execution Database Name
     select_columns:
       show_full_sql: Show Full Query Text
     refresh: Refresh

--- a/ui/lib/apps/SlowQuery/translations/zh.yaml
+++ b/ui/lib/apps/SlowQuery/translations/zh.yaml
@@ -126,9 +126,9 @@ slow_query:
       txn: 事务
   toolbar:
     schemas:
-      placeholder: 执行数据库
+      placeholder: 所有数据库
       selected: '{{ n }} 数据库'
-      columnTitle: 数据库名
+      columnTitle: 执行数据库名
     select_columns:
       show_full_sql: 显示完整 SQL 文本
     refresh: 刷新

--- a/ui/lib/apps/SlowQuery/translations/zh.yaml
+++ b/ui/lib/apps/SlowQuery/translations/zh.yaml
@@ -126,7 +126,7 @@ slow_query:
       txn: 事务
   toolbar:
     schemas:
-      placeholder: 所有数据库
+      placeholder: 执行数据库
       selected: '{{ n }} 数据库'
       columnTitle: 数据库名
     select_columns:

--- a/ui/lib/apps/Statement/translations/en.yaml
+++ b/ui/lib/apps/Statement/translations/en.yaml
@@ -22,7 +22,7 @@ statement:
     overview:
       toolbar:
         schemas:
-          placeholder: All Databases
+          placeholder: Execution Databases
           selected: '{{ n }} Databases'
           columnTitle: Database Name
         statement_types:

--- a/ui/lib/apps/Statement/translations/en.yaml
+++ b/ui/lib/apps/Statement/translations/en.yaml
@@ -22,9 +22,9 @@ statement:
     overview:
       toolbar:
         schemas:
-          placeholder: Execution Databases
+          placeholder: All Databases
           selected: '{{ n }} Databases'
-          columnTitle: Database Name
+          columnTitle: Execution Database Name
         statement_types:
           placeholder: All Kinds
           selected: '{{ n }} Kinds'

--- a/ui/lib/apps/Statement/translations/zh.yaml
+++ b/ui/lib/apps/Statement/translations/zh.yaml
@@ -22,9 +22,9 @@ statement:
     overview:
       toolbar:
         schemas:
-          placeholder: 执行数据库
+          placeholder: 所有数据库
           selected: '{{ n }} 数据库'
-          columnTitle: 数据库名
+          columnTitle: 执行数据库名
         statement_types:
           placeholder: 所有类型
           selected: '{{ n }} 类型'

--- a/ui/lib/apps/Statement/translations/zh.yaml
+++ b/ui/lib/apps/Statement/translations/zh.yaml
@@ -22,7 +22,7 @@ statement:
     overview:
       toolbar:
         schemas:
-          placeholder: 所有数据库
+          placeholder: 执行数据库
           selected: '{{ n }} 数据库'
           columnTitle: 数据库名
         statement_types:


### PR DESCRIPTION
The placeholder description of the db selection in the slow query & stmt toolbar is ambiguous. Now unified with detail page.

Update:
`所有数据库` -> `执行数据库`
`All Databases` -> `Execution Databases`