### PR TITLE
Fix endpoint scheme detection for TLS origination to PD

### DIFF
--- a/cmd/tidb-dashboard/main.go
+++ b/cmd/tidb-dashboard/main.go
@@ -98,9 +98,6 @@ func NewCLIConfig() *DashboardCLIConfig {
 	}
 
 	cfg.CoreConfig.NormalizePublicPathPrefix()
-	if err := cfg.CoreConfig.NormalizePDEndPoint(); err != nil {
-		log.Fatal("Invalid PD Endpoint", zap.Error(err))
-	}
 
 	// setup TLS config for TiDB components
 	if len(*clusterCaPath) != 0 && len(*clusterCertPath) != 0 && len(*clusterKeyPath) != 0 {
@@ -111,6 +108,10 @@ func NewCLIConfig() *DashboardCLIConfig {
 	// See https://github.com/pingcap/docs/blob/7a62321b3ce9318cbda8697503c920b2a01aeb3d/how-to/secure/enable-tls-clients.md#enable-authentication
 	if (len(*tidbCertPath) != 0 && len(*tidbKeyPath) != 0) || len(*tidbCaPath) != 0 {
 		cfg.CoreConfig.TiDBTLSConfig = buildTLSConfig(tidbCaPath, tidbKeyPath, tidbCertPath)
+	}
+
+	if err := cfg.CoreConfig.NormalizePDEndPoint(); err != nil {
+		log.Fatal("Invalid PD Endpoint", zap.Error(err))
 	}
 
 	// keyvisual check


### PR DESCRIPTION
`NormalizePDEndPoint` is responsible for setting the URL scheme of the PD endpoint ([ref](https://github.com/pingcap/tidb-dashboard/blob/f6c50593b5de31cd2f2eeeaf9dbf33cf396cb4c2/pkg/config/config.go#L55)). However, it's currently called *before* `cfg.CoreConfig.ClusterTLSConfig` is set, which causes Dashboard to make plaintext HTTP requests to PD all the time, regardless of whether `--cluster-[ca|cert|key]` flags are set.

This change fixes the TLS origination behavior by running this logic *after* `cfg.CoreConfig.ClusterTLSConfig` is (optionally) populated by `buildTLSConfig`. This allows Dashboard to properly use HTTPS to PD when cluster TLS is enabled.

I didn't find any existing unit tests to cover this change, but if there's a test I can add or update to cover this, I'm happy to include it in this PR.