### PR TITLE
Release v2021.09.02.r52.1 init

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - release
+      - release-5.2
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,7 +88,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        branch: [master, release-4.0, release-5.0, release-5.1, release-5.2]
+        branch: [release-5.2]
     steps:
       - name: Check out PD code base
         uses: actions/checkout@master

--- a/release-version
+++ b/release-version
@@ -1,3 +1,3 @@
 # This file specifies the TiDB Dashboard internal version, which will be printed in `--version`
 # and UI. In release branch, changing this file will result in publishing a new version and tag.
-2021.09.02.2
+2021.09.02.r52.1

--- a/ui/lib/apps/Statement/components/StatementsTable.tsx
+++ b/ui/lib/apps/Statement/components/StatementsTable.tsx
@@ -1,6 +1,12 @@
 import { usePersistFn } from 'ahooks'
 import React, { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
+import {
+  DetailsRow,
+  IDetailsListProps,
+  IDetailsRowStyles,
+} from 'office-ui-fabric-react'
+import { getTheme } from 'office-ui-fabric-react/lib/Styling'
 
 import openLink from '@lib/utils/openLink'
 import { CardTable, ICardTableProps } from '@lib/components'
@@ -11,6 +17,8 @@ import { IStatementTableController } from '../utils/useStatementTableController'
 interface Props extends Partial<ICardTableProps> {
   controller: IStatementTableController
 }
+
+const theme = getTheme()
 
 export default function StatementsTable({ controller, ...restPrpos }: Props) {
   const {
@@ -30,6 +38,10 @@ export default function StatementsTable({ controller, ...restPrpos }: Props) {
   const navigate = useNavigate()
   const handleRowClick = usePersistFn(
     (rec, idx, ev: React.MouseEvent<HTMLElement>) => {
+      // the evicted record's digest is empty string
+      if (!rec.digest) {
+        return
+      }
       saveClickedItemIndex(idx)
       const qs = DetailPage.buildQuery({
         digest: rec.digest,
@@ -57,6 +69,24 @@ export default function StatementsTable({ controller, ...restPrpos }: Props) {
       onRowClicked={handleRowClick}
       getKey={getKey}
       clickedRowIndex={getClickedItemIndex()}
+      onRenderRow={renderRow}
     />
   )
+}
+
+const renderRow: IDetailsListProps['onRenderRow'] = (props) => {
+  if (!props) {
+    return null
+  }
+
+  const customStyles: Partial<IDetailsRowStyles> = {}
+  // the evicted record's digest is empty string
+  if (!props.item.digest) {
+    customStyles.root = {
+      backgroundColor: theme.palette.neutralLighter,
+      cursor: 'not-allowed',
+    }
+  }
+
+  return <DetailsRow {...props} styles={customStyles} />
 }

--- a/ui/lib/components/CardTable/index.tsx
+++ b/ui/lib/components/CardTable/index.tsx
@@ -1,3 +1,4 @@
+import { IRenderFunction } from '@uifabric/utilities'
 import { usePersistFn } from 'ahooks'
 import { Checkbox } from 'antd'
 import cx from 'classnames'
@@ -10,6 +11,7 @@ import {
   IDetailsList,
   IDetailsListProps,
   SelectionMode,
+  IDetailsRowProps,
 } from 'office-ui-fabric-react/lib/DetailsList'
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
@@ -100,7 +102,11 @@ export interface ICardTableProps extends IDetailsListProps {
   clickedRowIndex?: number
 }
 
-function useRenderClickableRow(onRowClicked, clickedRowIdx) {
+function useRenderClickableRow(
+  onRowClicked,
+  clickedRowIdx,
+  customRender?: IRenderFunction<IDetailsRowProps> | undefined
+) {
   return useCallback(
     (props, defaultRender) => {
       if (!props) {
@@ -113,11 +119,11 @@ function useRenderClickableRow(onRowClicked, clickedRowIdx) {
           })}
           onClick={(ev) => onRowClicked?.(props.item, props.itemIndex, ev)}
         >
-          {defaultRender!(props)}
+          {customRender ? customRender(props) : defaultRender!(props)}
         </div>
       )
     },
-    [onRowClicked, clickedRowIdx]
+    [onRowClicked, clickedRowIdx, customRender]
   )
 }
 
@@ -153,11 +159,13 @@ export default function CardTable(props: ICardTableProps) {
     clickedRowIndex,
     columns,
     items,
+    onRenderRow,
     ...restProps
   } = props
   const renderClickableRow = useRenderClickableRow(
     onRowClicked,
-    clickedRowIndex || -1
+    clickedRowIndex || -1,
+    onRenderRow
   )
 
   const onColumnClick = usePersistFn(
@@ -246,7 +254,7 @@ export default function CardTable(props: ICardTableProps) {
             selectionMode={SelectionMode.none}
             constrainMode={ConstrainMode.unconstrained}
             layoutMode={DetailsListLayoutMode.justified}
-            onRenderRow={onRowClicked ? renderClickableRow : undefined}
+            onRenderRow={onRowClicked ? renderClickableRow : onRenderRow}
             columns={finalColumns}
             items={finalItems}
             componentRef={tableRef}


### PR DESCRIPTION
We will lock the tidb-dashboard version of the old tidb version until it is fully tested and refined.
A separate tidb-dashboard version `release-5.2` is needed to fix the Statement display issue due to the table definition changes in tidb 5.2.