### PR TITLE
Refactor: Fix godot incorrectly add dot suffix to annotations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,3 +52,7 @@ linters-settings:
   exhaustive:
     # only cover the case when default is not given
     default-signifies-exhaustive: true
+  godot:
+    # exclude swag annotations
+    exclude:
+      - "^\\s*@"

--- a/pkg/apiserver/clusterinfo/service.go
+++ b/pkg/apiserver/clusterinfo/service.go
@@ -85,7 +85,7 @@ func RegisterRouter(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 // @Success 200 "delete ok"
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Security JwtAuth
-// @Router /topology/tidb/{address} [delete].
+// @Router /topology/tidb/{address} [delete]
 func (s *Service) deleteTiDBTopology(c *gin.Context) {
 	address := c.Param("address")
 	errorChannel := make(chan error, 2)
@@ -124,7 +124,7 @@ func (s *Service) deleteTiDBTopology(c *gin.Context) {
 // @Success 200 {array} topology.TiDBInfo
 // @Router /topology/tidb [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) getTiDBTopology(c *gin.Context) {
 	instances, err := topology.FetchTiDBTopology(s.lifecycleCtx, s.params.EtcdClient)
 	if err != nil {
@@ -144,7 +144,7 @@ type StoreTopologyResponse struct {
 // @Success 200 {object} StoreTopologyResponse
 // @Router /topology/store [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) getStoreTopology(c *gin.Context) {
 	tikvInstances, tiFlashInstances, err := topology.FetchStoreTopology(s.params.PDClient)
 	if err != nil {
@@ -162,7 +162,7 @@ func (s *Service) getStoreTopology(c *gin.Context) {
 // @Success 200 {object} topology.StoreLocation
 // @Router /topology/store_location [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) getStoreLocationTopology(c *gin.Context) {
 	storeLocation, err := topology.FetchStoreLocation(s.params.PDClient)
 	if err != nil {
@@ -177,7 +177,7 @@ func (s *Service) getStoreLocationTopology(c *gin.Context) {
 // @Success 200 {array} topology.PDInfo
 // @Router /topology/pd [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) getPDTopology(c *gin.Context) {
 	instances, err := topology.FetchPDTopology(s.params.PDClient)
 	if err != nil {
@@ -192,7 +192,7 @@ func (s *Service) getPDTopology(c *gin.Context) {
 // @Success 200 {object} topology.AlertManagerInfo
 // @Router /topology/alertmanager [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) getAlertManagerTopology(c *gin.Context) {
 	instance, err := topology.FetchAlertManagerTopology(s.lifecycleCtx, s.params.EtcdClient)
 	if err != nil {
@@ -207,7 +207,7 @@ func (s *Service) getAlertManagerTopology(c *gin.Context) {
 // @Success 200 {object} topology.GrafanaInfo
 // @Router /topology/grafana [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) getGrafanaTopology(c *gin.Context) {
 	instance, err := topology.FetchGrafanaTopology(s.lifecycleCtx, s.params.EtcdClient)
 	if err != nil {
@@ -223,7 +223,7 @@ func (s *Service) getGrafanaTopology(c *gin.Context) {
 // @Param address path string true "ip:port"
 // @Router /topology/alertmanager/{address}/count [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) getAlertManagerCounts(c *gin.Context) {
 	address := c.Param("address")
 	cnt, err := fetchAlertManagerCounts(s.lifecycleCtx, address, s.params.HTTPClient)
@@ -244,7 +244,7 @@ type GetHostsInfoResponse struct {
 // @Router /host/all [get]
 // @Security JwtAuth
 // @Success 200 {object} GetHostsInfoResponse
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) getHostsInfo(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 
@@ -270,7 +270,7 @@ func (s *Service) getHostsInfo(c *gin.Context) {
 // @Router /host/statistics [get]
 // @Security JwtAuth
 // @Success 200 {object} ClusterStatistics
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) getStatistics(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	stats, err := s.calculateStatistics(db)

--- a/pkg/apiserver/configuration/router.go
+++ b/pkg/apiserver/configuration/router.go
@@ -38,7 +38,7 @@ func RegisterRouter(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 // @Security JwtAuth
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 403 {object} utils.APIError "Experimental feature not enabled"
-// @Failure 500 {object} utils.APIError "Internal error".
+// @Failure 500 {object} utils.APIError "Internal error"
 func (s *Service) getHandler(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	r, err := s.getAllConfigItems(db)
@@ -68,7 +68,7 @@ type EditResponse struct {
 // @Failure 400 {object} utils.APIError "Bad request"
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 403 {object} utils.APIError "Experimental feature not enabled"
-// @Failure 500 {object} utils.APIError "Internal error".
+// @Failure 500 {object} utils.APIError "Internal error"
 func (s *Service) editHandler(c *gin.Context) {
 	var req EditRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/pkg/apiserver/conprof/service.go
+++ b/pkg/apiserver/conprof/service.go
@@ -178,7 +178,7 @@ type NgMonitoringConfig struct {
 // @Router /continuous_profiling/config [get]
 // @Security JwtAuth
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) conprofConfig(c *gin.Context) {
 	// dummy, for generate openapi
 }
@@ -189,7 +189,7 @@ func (s *Service) conprofConfig(c *gin.Context) {
 // @Security JwtAuth
 // @Success 200 {string} string "ok"
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) updateConprofConfig(c *gin.Context) {
 	// dummy, for generate openapi
 }
@@ -206,7 +206,7 @@ type Component struct {
 // @Router /continuous_profiling/components [get]
 // @Security JwtAuth
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) conprofComponents(c *gin.Context) {
 	// dummy, for generate openapi
 }
@@ -221,7 +221,7 @@ type EstimateSizeRes struct {
 // @Security JwtAuth
 // @Success 200 {object} EstimateSizeRes
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) estimateSize(c *gin.Context) {
 	// dummy, for generate openapi
 }
@@ -270,7 +270,7 @@ type Target struct {
 // @Security JwtAuth
 // @Success 200 {array} GroupProfiles
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) conprofGroupProfiles(c *gin.Context) {
 	// dummy, for generate openapi
 }
@@ -281,7 +281,7 @@ func (s *Service) conprofGroupProfiles(c *gin.Context) {
 // @Security JwtAuth
 // @Success 200 {object} GroupProfileDetail
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) conprofGroupProfileDetail(c *gin.Context) {
 	// dummy, for generate openapi
 }
@@ -292,7 +292,7 @@ func (s *Service) conprofGroupProfileDetail(c *gin.Context) {
 // @Security JwtAuth
 // @Success 200 {string} string
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) genConprofActionToken(c *gin.Context) {
 	q := c.Query("q")
 	token, err := utils.NewJWTString("conprof", q)
@@ -309,7 +309,7 @@ func (s *Service) genConprofActionToken(c *gin.Context) {
 // @Security JwtAuth
 // @Produce application/x-gzip
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) conprofDownload(c *gin.Context) {
 	// dummy, for generate openapi
 }
@@ -327,7 +327,7 @@ type ViewSingleProfileReq struct {
 // @Security JwtAuth
 // @Produce html
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) conprofViewProfile(c *gin.Context) {
 	// dummy, for generate openapi
 }

--- a/pkg/apiserver/debugapi/service.go
+++ b/pkg/apiserver/debugapi/service.go
@@ -74,7 +74,7 @@ func getExtFromContentTypeHeader(contentType string) string {
 // @Failure 400 {object} utils.APIError "Bad request"
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /debug_api/endpoint [post].
+// @Router /debug_api/endpoint [post]
 func (s *Service) RequestEndpoint(c *gin.Context) {
 	var req endpoint.RequestPayload
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -115,12 +115,12 @@ func (s *Service) RequestEndpoint(c *gin.Context) {
 	c.String(http.StatusOK, token)
 }
 
-// @Summary Download a finished request result.
+// @Summary Download a finished request result
 // @Param token query string true "download token"
 // @Success 200 {object} string
 // @Failure 400 {object} utils.APIError "Bad request"
 // @Failure 500 {object} utils.APIError
-// @Router /debug_api/download [get].
+// @Router /debug_api/download [get]
 func (s *Service) Download(c *gin.Context) {
 	token := c.Query("token")
 	utils.FSServe(c, token, tokenIssuer)
@@ -131,7 +131,7 @@ func (s *Service) Download(c *gin.Context) {
 // @Security JwtAuth
 // @Success 200 {array} endpoint.APIModel
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Router /debug_api/endpoints [get].
+// @Router /debug_api/endpoints [get]
 func (s *Service) GetEndpoints(c *gin.Context) {
 	c.JSON(http.StatusOK, s.Client.GetAllAPIModels())
 }

--- a/pkg/apiserver/diagnose/diagnose.go
+++ b/pkg/apiserver/diagnose/diagnose.go
@@ -90,7 +90,7 @@ type GenerateReportRequest struct {
 // @Success 200 {array} Report
 // @Router /diagnose/reports [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) reportsHandler(c *gin.Context) {
 	reports, err := GetReports(s.db)
 	if err != nil {
@@ -107,7 +107,7 @@ func (s *Service) reportsHandler(c *gin.Context) {
 // @Router /diagnose/reports [post]
 // @Security JwtAuth
 // @Failure 400 {object} utils.APIError "Bad request"
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) genReportHandler(c *gin.Context) {
 	var req GenerateReportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -161,7 +161,7 @@ func (s *Service) genReportHandler(c *gin.Context) {
 // @Success 200 {object} Report
 // @Router /diagnose/reports/{id}/status [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) reportStatusHandler(c *gin.Context) {
 	id := c.Param("id")
 	report, err := GetReport(s.db, id)
@@ -177,7 +177,7 @@ func (s *Service) reportStatusHandler(c *gin.Context) {
 // @Produce html
 // @Param id path string true "report id"
 // @Success 200 {string} string
-// @Router /diagnose/reports/{id}/detail [get].
+// @Router /diagnose/reports/{id}/detail [get]
 func (s *Service) reportHTMLHandler(c *gin.Context) {
 	defer func(old string) {
 		c.Request.URL.Path = old
@@ -192,7 +192,7 @@ func (s *Service) reportHTMLHandler(c *gin.Context) {
 // @Produce text/javascript
 // @Param id path string true "report id"
 // @Success 200 {string} string
-// @Router /diagnose/reports/{id}/data.js [get].
+// @Router /diagnose/reports/{id}/data.js [get]
 func (s *Service) reportDataHandler(c *gin.Context) {
 	id := c.Param("id")
 	report, err := GetReport(s.db, id)
@@ -218,7 +218,7 @@ type GenDiagnosisReportRequest struct {
 // @Success 200 {object} TableDef
 // @Router /diagnose/diagnosis [post]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) genDiagnosisHandler(c *gin.Context) {
 	var req GenDiagnosisReportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/pkg/apiserver/info/info.go
+++ b/pkg/apiserver/info/info.go
@@ -70,7 +70,7 @@ type InfoResponse struct { //nolint
 // @Success 200 {object} InfoResponse
 // @Router /info/info [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) infoHandler(c *gin.Context) {
 	supportedFeatures := []string{}
 	if conprof.IsFeatureSupport(s.params.Config) {
@@ -100,7 +100,7 @@ type WhoAmIResponse struct {
 // @Success 200 {object} WhoAmIResponse
 // @Router /info/whoami [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) whoamiHandler(c *gin.Context) {
 	sessionUser := utils.GetSession(c)
 	resp := WhoAmIResponse{
@@ -116,7 +116,7 @@ func (s *Service) whoamiHandler(c *gin.Context) {
 // @Success 200 {object} []string
 // @Router /info/databases [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) databasesHandler(c *gin.Context) {
 	type databaseSchemas struct {
 		Databases string `gorm:"column:Database"`
@@ -147,7 +147,7 @@ type tableSchema struct {
 // @Router /info/tables [get]
 // @Param database_name query string false "Database name"
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) tablesHandler(c *gin.Context) {
 	var result []tableSchema
 	db := utils.GetTiDBConnection(c)

--- a/pkg/apiserver/logsearch/service.go
+++ b/pkg/apiserver/logsearch/service.go
@@ -111,7 +111,7 @@ type TaskGroupResponse struct {
 // @Failure 400 {object} utils.APIError "Bad request"
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /logs/taskgroup [put].
+// @Router /logs/taskgroup [put]
 func (s *Service) CreateTaskGroup(c *gin.Context) {
 	var req CreateTaskGroupRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -159,7 +159,7 @@ func (s *Service) CreateTaskGroup(c *gin.Context) {
 // @Success 200 {array} TaskGroupModel
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /logs/taskgroups [get].
+// @Router /logs/taskgroups [get]
 func (s *Service) GetAllTaskGroups(c *gin.Context) {
 	var taskGroups []*TaskGroupModel
 	err := s.db.Find(&taskGroups).Error
@@ -177,7 +177,7 @@ func (s *Service) GetAllTaskGroups(c *gin.Context) {
 // @Success 200 {object} TaskGroupResponse
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /logs/taskgroups/{id} [get].
+// @Router /logs/taskgroups/{id} [get]
 func (s *Service) GetTaskGroup(c *gin.Context) {
 	taskGroupID := c.Param("id")
 	var taskGroup TaskGroupModel
@@ -205,7 +205,7 @@ func (s *Service) GetTaskGroup(c *gin.Context) {
 // @Success 200 {array} PreviewModel
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /logs/taskgroups/{id}/preview [get].
+// @Router /logs/taskgroups/{id}/preview [get]
 func (s *Service) GetTaskGroupPreview(c *gin.Context) {
 	taskGroupID := c.Param("id")
 	var lines []PreviewModel
@@ -228,7 +228,7 @@ func (s *Service) GetTaskGroupPreview(c *gin.Context) {
 // @Failure 400 {object} utils.APIError
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /logs/taskgroups/{id}/retry [post].
+// @Router /logs/taskgroups/{id}/retry [post]
 func (s *Service) RetryTask(c *gin.Context) {
 	taskGroupID, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -276,7 +276,7 @@ func (s *Service) RetryTask(c *gin.Context) {
 // @Success 200 {object} utils.APIEmptyResponse
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 400 {object} utils.APIError
-// @Router /logs/taskgroups/{id}/cancel [post].
+// @Router /logs/taskgroups/{id}/cancel [post]
 func (s *Service) CancelTask(c *gin.Context) {
 	taskGroupID, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -303,7 +303,7 @@ func (s *Service) CancelTask(c *gin.Context) {
 // @Success 200 {object} utils.APIEmptyResponse
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /logs/taskgroups/{id} [delete].
+// @Router /logs/taskgroups/{id} [delete]
 func (s *Service) DeleteTaskGroup(c *gin.Context) {
 	taskGroupID := c.Param("id")
 	taskGroup := TaskGroupModel{}
@@ -323,7 +323,7 @@ func (s *Service) DeleteTaskGroup(c *gin.Context) {
 // @Success 200 {string} string "xxx"
 // @Failure 400 {object} utils.APIError
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Router /logs/download/acquire_token [get].
+// @Router /logs/download/acquire_token [get]
 func (s *Service) GetDownloadToken(c *gin.Context) {
 	ids := c.QueryArray("id")
 	str := strings.Join(ids, ",")
@@ -341,7 +341,7 @@ func (s *Service) GetDownloadToken(c *gin.Context) {
 // @Failure 400 {object} utils.APIError
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /logs/download [get].
+// @Router /logs/download [get]
 func (s *Service) DownloadLogs(c *gin.Context) {
 	token := c.Query("token")
 	str, err := utils.ParseJWTString("logs/download", token)

--- a/pkg/apiserver/metrics/router.go
+++ b/pkg/apiserver/metrics/router.go
@@ -52,7 +52,7 @@ func RegisterRouter(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 // @Success 200 {object} QueryResponse
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Security JwtAuth
-// @Router /metrics/query [get].
+// @Router /metrics/query [get]
 func (s *Service) queryMetrics(c *gin.Context) {
 	var req QueryRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
@@ -114,7 +114,7 @@ type GetPromAddressConfigResponse struct {
 // @Success 200 {object} GetPromAddressConfigResponse
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Security JwtAuth
-// @Router /metrics/prom_address [get].
+// @Router /metrics/prom_address [get]
 func (s *Service) getPromAddressConfig(c *gin.Context) {
 	cAddr, err := s.resolveCustomizedPromAddress(true)
 	if err != nil {
@@ -146,7 +146,7 @@ type PutCustomPromAddressResponse struct {
 // @Success 200 {object} PutCustomPromAddressResponse
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Security JwtAuth
-// @Router /metrics/prom_address [put].
+// @Router /metrics/prom_address [put]
 func (s *Service) putCustomPromAddress(c *gin.Context) {
 	var req PutCustomPromAddressRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/pkg/apiserver/profiling/router.go
+++ b/pkg/apiserver/profiling/router.go
@@ -56,7 +56,7 @@ func RegisterRouter(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 // @Failure 400 {object} utils.APIError "Bad request"
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /profiling/group/start [post].
+// @Router /profiling/group/start [post]
 func (s *Service) handleStartGroup(c *gin.Context) {
 	var req StartRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -98,7 +98,7 @@ func (s *Service) handleStartGroup(c *gin.Context) {
 // @Security JwtAuth
 // @Success 200 {array} TaskGroupModel
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Router /profiling/group/list [get].
+// @Router /profiling/group/list [get]
 func (s *Service) getGroupList(c *gin.Context) {
 	var resp []TaskGroupModel
 	err := s.params.LocalStore.Order("id DESC").Find(&resp).Error
@@ -123,7 +123,7 @@ type GroupDetailResponse struct {
 // @Success 200 {object} GroupDetailResponse
 // @Failure 400 {object} utils.APIError
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Router /profiling/group/detail/{groupId} [get].
+// @Router /profiling/group/detail/{groupId} [get]
 func (s *Service) getGroupDetail(c *gin.Context) {
 	taskGroupID, err := strconv.Atoi(c.Param("groupId"))
 	if err != nil {
@@ -159,7 +159,7 @@ func (s *Service) getGroupDetail(c *gin.Context) {
 // @Success 200 {object} utils.APIEmptyResponse
 // @Failure 400 {object} utils.APIError
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Router /profiling/group/cancel/{groupId} [post].
+// @Router /profiling/group/cancel/{groupId} [post]
 func (s *Service) handleCancelGroup(c *gin.Context) {
 	taskGroupID, err := strconv.Atoi(c.Param("groupId"))
 	if err != nil {
@@ -184,7 +184,7 @@ func (s *Service) handleCancelGroup(c *gin.Context) {
 // @Failure 400 {object} utils.APIError
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /profiling/action_token [get].
+// @Router /profiling/action_token [get]
 func (s *Service) getActionToken(c *gin.Context) {
 	id := c.Query("id")
 	action := c.Query("action") // group_download, single_download, single_view
@@ -205,7 +205,7 @@ func (s *Service) getActionToken(c *gin.Context) {
 // @Failure 400 {object} utils.APIError
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /profiling/group/download [get].
+// @Router /profiling/group/download [get]
 func (s *Service) downloadGroup(c *gin.Context) {
 	token := c.Query("token")
 	str, err := utils.ParseJWTString("profiling/group_download", token)
@@ -248,7 +248,7 @@ func (s *Service) downloadGroup(c *gin.Context) {
 // @Failure 400 {object} utils.APIError
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /profiling/single/download [get].
+// @Router /profiling/single/download [get]
 func (s *Service) downloadSingle(c *gin.Context) {
 	// FIXME: We can simply provide only a single file
 	token := c.Query("token")
@@ -287,7 +287,7 @@ func (s *Service) downloadSingle(c *gin.Context) {
 // @Failure 400 {object} utils.APIError
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /profiling/single/view [get].
+// @Router /profiling/single/view [get]
 func (s *Service) viewSingle(c *gin.Context) {
 	token := c.Query("token")
 	str, err := utils.ParseJWTString("profiling/single_view", token)
@@ -324,7 +324,7 @@ func (s *Service) viewSingle(c *gin.Context) {
 // @Failure 400 {object} utils.APIError
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Failure 500 {object} utils.APIError
-// @Router /profiling/group/delete/{groupId} [delete].
+// @Router /profiling/group/delete/{groupId} [delete]
 func (s *Service) deleteGroup(c *gin.Context) {
 	taskGroupID, err := strconv.Atoi(c.Param("groupId"))
 	if err != nil {
@@ -352,7 +352,7 @@ func (s *Service) deleteGroup(c *gin.Context) {
 // @Router /profiling/config [get]
 // @Security JwtAuth
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) getDynamicConfig(c *gin.Context) {
 	dc, err := s.params.ConfigManager.Get()
 	if err != nil {
@@ -369,7 +369,7 @@ func (s *Service) getDynamicConfig(c *gin.Context) {
 // @Security JwtAuth
 // @Failure 400 {object} utils.APIError "Bad request"
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) setDynamicConfig(c *gin.Context) {
 	var req config.ProfilingConfig
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/pkg/apiserver/queryeditor/service.go
+++ b/pkg/apiserver/queryeditor/service.go
@@ -129,7 +129,7 @@ func executeStatements(context context.Context, db *sql.DB, statements string) (
 // @Security JwtAuth
 // @Failure 400 {object} utils.APIError "Bad request"
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 403 {object} utils.APIError "Experimental feature not enabled".
+// @Failure 403 {object} utils.APIError "Experimental feature not enabled"
 func (s *Service) runHandler(c *gin.Context) {
 	var req RunRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/pkg/apiserver/slowquery/service.go
+++ b/pkg/apiserver/slowquery/service.go
@@ -74,7 +74,7 @@ func registerRouter(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 // @Router /slow_query/list [get]
 // @Security JwtAuth
 // @Failure 400 {object} utils.APIError "Bad request"
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) getList(c *gin.Context) {
 	var req GetListRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
@@ -96,7 +96,7 @@ func (s *Service) getList(c *gin.Context) {
 // @Success 200 {object} Model
 // @Router /slow_query/detail [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) getDetails(c *gin.Context) {
 	var req GetDetailRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
@@ -120,7 +120,7 @@ func (s *Service) getDetails(c *gin.Context) {
 // @Success 200 {string} string "xxx"
 // @Security JwtAuth
 // @Failure 400 {object} utils.APIError "Bad request"
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) downloadTokenHandler(c *gin.Context) {
 	var req GetListRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -171,7 +171,7 @@ func (s *Service) downloadTokenHandler(c *gin.Context) {
 // @Produce text/csv
 // @Param token query string true "download token"
 // @Failure 400 {object} utils.APIError
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) downloadHandler(c *gin.Context) {
 	token := c.Query("token")
 	utils.DownloadByToken(token, "slowquery/download", c)
@@ -183,7 +183,7 @@ func (s *Service) downloadHandler(c *gin.Context) {
 // @Failure 400 {object} utils.APIError "Bad request"
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Security JwtAuth
-// @Router /slow_query/table_columns [get].
+// @Router /slow_query/table_columns [get]
 func (s *Service) queryTableColumns(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	cs, err := s.params.SysSchema.GetTableColumnNames(db, slowQueryTable)

--- a/pkg/apiserver/statement/service.go
+++ b/pkg/apiserver/statement/service.go
@@ -86,7 +86,7 @@ type EditableConfig struct {
 // @Success 200 {object} statement.EditableConfig
 // @Router /statements/config [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) configHandler(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	cfg := &EditableConfig{}
@@ -103,7 +103,7 @@ func (s *Service) configHandler(c *gin.Context) {
 // @Success 204 {object} string
 // @Router /statements/config [post]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) modifyConfigHandler(c *gin.Context) {
 	var config EditableConfig
 	if err := c.ShouldBindJSON(&config); err != nil {
@@ -131,7 +131,7 @@ func (s *Service) modifyConfigHandler(c *gin.Context) {
 // @Success 200 {array} statement.TimeRange
 // @Router /statements/time_ranges [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) timeRangesHandler(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	timeRanges, err := queryTimeRanges(db)
@@ -146,7 +146,7 @@ func (s *Service) timeRangesHandler(c *gin.Context) {
 // @Success 200 {array} string
 // @Router /statements/stmt_types [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) stmtTypesHandler(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	stmtTypes, err := queryStmtTypes(db)
@@ -172,7 +172,7 @@ type GetStatementsRequest struct {
 // @Router /statements/list [get]
 // @Security JwtAuth
 // @Failure 400 {object} utils.APIError "Bad request"
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) listHandler(c *gin.Context) {
 	var req GetStatementsRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
@@ -210,7 +210,7 @@ type GetPlansRequest struct {
 // @Success 200 {array} Model
 // @Router /statements/plans [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) plansHandler(c *gin.Context) {
 	var req GetPlansRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
@@ -236,7 +236,7 @@ type GetPlanDetailRequest struct {
 // @Success 200 {object} Model
 // @Router /statements/plan/detail [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) planDetailHandler(c *gin.Context) {
 	var req GetPlanDetailRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
@@ -259,7 +259,7 @@ func (s *Service) planDetailHandler(c *gin.Context) {
 // @Success 200 {string} string "xxx"
 // @Security JwtAuth
 // @Failure 400 {object} utils.APIError "Bad request"
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) downloadTokenHandler(c *gin.Context) {
 	var req GetStatementsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -316,7 +316,7 @@ func (s *Service) downloadTokenHandler(c *gin.Context) {
 // @Produce text/csv
 // @Param token query string true "download token"
 // @Failure 400 {object} utils.APIError
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) downloadHandler(c *gin.Context) {
 	token := c.Query("token")
 	utils.DownloadByToken(token, "statements/download", c)
@@ -327,7 +327,7 @@ func (s *Service) downloadHandler(c *gin.Context) {
 // @Success 200 {array} string
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
 // @Security JwtAuth
-// @Router /statements/table_columns [get].
+// @Router /statements/table_columns [get]
 func (s *Service) queryTableColumns(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	cs, err := s.params.SysSchema.GetTableColumnNames(db, statementsTable)

--- a/pkg/apiserver/user/auth.go
+++ b/pkg/apiserver/user/auth.go
@@ -289,9 +289,9 @@ type GetLoginInfoResponse struct {
 }
 
 // @ID userGetLoginInfo
-// @Summary Get log in information, like supported authenticate types.
+// @Summary Get log in information, like supported authenticate types
 // @Success 200 {object} GetLoginInfoResponse
-// @Router /user/login_info [get].
+// @Router /user/login_info [get]
 func (s *AuthService) getLoginInfoHandler(c *gin.Context) {
 	supportedAuth := make([]int, 0)
 	for typeID, a := range s.authenticators {
@@ -316,7 +316,7 @@ func (s *AuthService) getLoginInfoHandler(c *gin.Context) {
 // @Param message body AuthenticateForm true "Credentials"
 // @Success 200 {object} TokenResponse
 // @Failure 401 {object} utils.APIError
-// @Router /user/login [post].
+// @Router /user/login [post]
 func (s *AuthService) loginHandler(c *gin.Context) {
 	s.middleware.LoginHandler(c)
 }
@@ -332,7 +332,7 @@ type GetSignOutInfoRequest struct {
 // @Router /user/sign_out_info [get]
 // @Security JwtAuth
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError "Internal error".
+// @Failure 500 {object} utils.APIError "Internal error"
 func (s *AuthService) getSignOutInfoHandler(c *gin.Context) {
 	var req GetSignOutInfoRequest
 	if err := c.ShouldBindQuery(&req); err != nil {

--- a/pkg/apiserver/user/code/router.go
+++ b/pkg/apiserver/user/code/router.go
@@ -30,7 +30,7 @@ type ShareResponse struct {
 // @Param request body ShareRequest true "Request body"
 // @Security JwtAuth
 // @Success 200 {object} ShareResponse
-// @Router /user/share/code [post].
+// @Router /user/share/code [post]
 func (s *Service) shareHandler(c *gin.Context) {
 	var req ShareRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/pkg/apiserver/user/sso/router.go
+++ b/pkg/apiserver/user/sso/router.go
@@ -32,7 +32,7 @@ type GetAuthURLRequest struct {
 // @Summary Get SSO Auth URL
 // @Param q query GetAuthURLRequest true "Query"
 // @Success 200 {string} string
-// @Router /user/sso/auth_url [get].
+// @Router /user/sso/auth_url [get]
 func (s *Service) getAuthURLHandler(c *gin.Context) {
 	var req GetAuthURLRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
@@ -52,7 +52,7 @@ func (s *Service) getAuthURLHandler(c *gin.Context) {
 // @Success 200 {array} SSOImpersonationModel
 // @Router /user/sso/impersonations/list [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) listImpersonationHandler(c *gin.Context) {
 	var resp []SSOImpersonationModel
 	err := s.params.LocalStore.Find(&resp).Error
@@ -76,7 +76,7 @@ type CreateImpersonationRequest struct {
 // @Security JwtAuth
 // @Failure 400 {object} utils.APIError "Bad request"
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError "Internal error".
+// @Failure 500 {object} utils.APIError "Internal error"
 func (s *Service) createImpersonationHandler(c *gin.Context) {
 	var req CreateImpersonationRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -102,7 +102,7 @@ func (s *Service) createImpersonationHandler(c *gin.Context) {
 // @Router /user/sso/config [get]
 // @Security JwtAuth
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) getConfig(c *gin.Context) {
 	dc, err := s.params.ConfigManager.Get()
 	if err != nil {
@@ -124,7 +124,7 @@ type SetConfigRequest struct {
 // @Security JwtAuth
 // @Failure 400 {object} utils.APIError "Bad request"
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError "Internal error".
+// @Failure 500 {object} utils.APIError "Internal error"
 func (s *Service) setConfig(c *gin.Context) {
 	var req SetConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/pkg/keyvisual/manager.go
+++ b/pkg/keyvisual/manager.go
@@ -102,7 +102,7 @@ func (s *Service) stopService() {
 // @Router /keyvisual/config [get]
 // @Security JwtAuth
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) getDynamicConfig(c *gin.Context) {
 	dc, err := s.cfgManager.Get()
 	if err != nil {
@@ -119,7 +119,7 @@ func (s *Service) getDynamicConfig(c *gin.Context) {
 // @Security JwtAuth
 // @Failure 400 {object} utils.APIError
 // @Failure 401 {object} utils.APIError "Unauthorized failure"
-// @Failure 500 {object} utils.APIError.
+// @Failure 500 {object} utils.APIError
 func (s *Service) setDynamicConfig(c *gin.Context) {
 	var req config.KeyVisualConfig
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/pkg/keyvisual/service.go
+++ b/pkg/keyvisual/service.go
@@ -237,7 +237,7 @@ func (s *Service) Stop(ctx context.Context) error {
 // @Success 200 {object} matrix.Matrix
 // @Router /keyvisual/heatmaps [get]
 // @Security JwtAuth
-// @Failure 401 {object} utils.APIError "Unauthorized failure".
+// @Failure 401 {object} utils.APIError "Unauthorized failure"
 func (s *Service) heatmaps(c *gin.Context) {
 	startKey := c.Query("startkey")
 	endKey := c.Query("endkey")


### PR DESCRIPTION
In https://github.com/pingcap/tidb-dashboard/pull/1052 we incorrectly added a dot suffix to all annotations. This PR reverted it back and added exclude rules to the linter.