### PR TITLE
fix potential panic when GetPDInstances

### DIFF
--- a/util/topo/pd.go
+++ b/util/topo/pd.go
@@ -45,6 +45,7 @@ func GetPDInstances(pdAPI *pdclient.APIClient) ([]PDInfo, error) {
 				zap.String("component", distro.R().PD),
 				zap.String("targetNode", u),
 				zap.Error(err))
+			tsResp = &pdclient.GetStatusResponse{}
 		}
 
 		storeStatus := ComponentStatusUnreachable


### PR DESCRIPTION
Signed-off-by: crazycs <chen.two.cs@gmail.com>

```go
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x18a874d]

goroutine 122 [running]:
testing.tRunner.func1.2(0x1c59c20, 0x2690700)
        /Users/cs/code/goread/src/github.com/golang/go/src/testing/testing.go:1144 +0x332
testing.tRunner.func1(0xc000198300)
        /Users/cs/code/goread/src/github.com/golang/go/src/testing/testing.go:1147 +0x4b6
panic(0x1c59c20, 0x2690700)
        /Users/cs/code/goread/src/github.com/golang/go/src/runtime/panic.go:965 +0x1b9
github.com/pingcap/tidb-dashboard/util/topo.GetPDInstances(0xc00069c148, 0x0, 0x26e2578, 0x0, 0x0, 0x0)
        /Users/cs/code/goread/pkg/mod/github.com/pingcap/tidb-dashboard/util@v0.0.0-20211014081729-82f8b809f5ae/topo/pd.go:73 +0x82d
```