### PR TITLE
chore: fix profileURL of speedscope

### DIFF
--- a/ui/lib/apps/InstanceProfiling/pages/Detail.tsx
+++ b/ui/lib/apps/InstanceProfiling/pages/Detail.tsx
@@ -127,7 +127,7 @@ export default function Page() {
       }
 
       // make both generated graph(svg) file and protobuf file viewable online
-      let profileURL = `${client.getBasePath()}/profiling/single/view?token=${token}`
+      let profileURL = `${client.getApiBaseURL()}/profiling/single/view?token=${token}`
 
       if (rec.profile_output_type === 'protobuf') {
         const titleOnTab = rec.target.kind + '_' + rec.target.display_name

--- a/ui/lib/client/baseUrl.ts
+++ b/ui/lib/client/baseUrl.ts
@@ -1,6 +1,6 @@
 import publicPathPrefix from '@lib/utils/publicPathPrefix'
 
-export const API_HOST = (function getApiHost(): string {
+export const API_BASEPATH_PREFIX = (function getApiPathPrefix(): string {
   let apiPrefix
   if (process.env.NODE_ENV === 'development') {
     if (process.env.REACT_APP_DASHBOARD_API_URL) {
@@ -16,5 +16,9 @@ export const API_HOST = (function getApiHost(): string {
 })()
 
 export function getApiBasePath(): string {
-  return `${API_HOST}/api`
+  return `${API_BASEPATH_PREFIX}/api`
+}
+
+export function getApiOrigin(): string {
+  return `${window.location.origin}`
 }

--- a/ui/lib/client/index.tsx
+++ b/ui/lib/client/index.tsx
@@ -10,7 +10,7 @@ import * as i18n from '@lib/utils/i18n'
 import { reportError } from '@lib/utils/sentryHelpers'
 
 import { DefaultApi } from './api'
-import { getApiBasePath } from './baseUrl'
+import { getApiBasePath, getApiOrigin } from './baseUrl'
 
 export * from './api'
 
@@ -38,11 +38,19 @@ function getBasePath(): string {
   return basePath
 }
 
+function getApiBaseURL(): string {
+  if (process.env.NODE_ENV === 'development') {
+    return basePath
+  }
+  const origin = getApiOrigin()
+  return `${origin}${basePath}`
+}
+
 function getAxiosInstance(): AxiosInstance {
   return rawAxiosInstance
 }
 
-export default { getInstance, getBasePath, getAxiosInstance }
+export default { getInstance, getBasePath, getAxiosInstance, getApiBaseURL }
 
 //////////////////////////////
 


### PR DESCRIPTION
The `client.getBasePath` will only return API basePath in prod mode, however, speedscope profileURL requires `${apiOrigin}${apiBasePath}` both in dev and prod mode. This PR fixed api baseURL of speedscope profileURL in prod mode. 