### PR TITLE
Fix script to embed the ui

### DIFF
--- a/scripts/distro/write_strings.sh
+++ b/scripts/distro/write_strings.sh
@@ -14,7 +14,8 @@ if [[ -f "${PROJECT_DIR}/internal/resource/distrores/strings.go" ]]; then
 fi
 
 echo "+ Write resource strings"
-go run -tags="${BUILD_TAG}" "${PROJECT_DIR}/scripts/distro/write_strings.go" -o="${PROJECT_DIR}/ui/lib/distribution.json"
+cd "$PROJECT_DIR/scripts"
+go run -tags="${BUILD_TAG}" distro/write_strings.go -o="${PROJECT_DIR}/ui/lib/distribution.json"
 
 echo "  - Success! Resource strings:"
 cat "${PROJECT_DIR}/ui/lib/distribution.json"

--- a/scripts/distro/write_strings.sh
+++ b/scripts/distro/write_strings.sh
@@ -14,8 +14,10 @@ if [[ -f "${PROJECT_DIR}/internal/resource/distrores/strings.go" ]]; then
 fi
 
 echo "+ Write resource strings"
-cd "$PROJECT_DIR/scripts"
-go run -tags="${BUILD_TAG}" distro/write_strings.go -o="${PROJECT_DIR}/ui/lib/distribution.json"
+cd "$PROJECT_DIR"
+# FIXME: distro/write_strings needs to access the /internal package, which is not allowed to be invoked in another module
+# Currently we workaround this by invoking in the TiDB Dashboard module.
+go run -tags="${BUILD_TAG}" scripts/distro/write_strings.go -o="${PROJECT_DIR}/ui/lib/distribution.json"
 
 echo "  - Success! Resource strings:"
 cat "${PROJECT_DIR}/ui/lib/distribution.json"

--- a/scripts/embed_ui_assets.sh
+++ b/scripts/embed_ui_assets.sh
@@ -14,13 +14,11 @@ set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 PROJECT_DIR=$(cd "$DIR/.."; pwd)
 
-cd "$PROJECT_DIR"
-
 export GOBIN=$PROJECT_DIR/bin
 export PATH=$GOBIN:$PATH
 
 echo "+ Preflight check"
-if [ ! -d "ui/build" ]; then
+if [ ! -d "$PROJECT_DIR/ui/build" ]; then
   echo "  - Error: UI assets must be built first"
   exit 1
 fi
@@ -33,8 +31,9 @@ fi
 
 echo "+ Embed UI assets"
 
-go run scripts/generate_assets.go $BUILD_TAG_PARAMETER
+cd "$PROJECT_DIR/scripts"
+go run generate_assets.go "$PROJECT_DIR/ui/build" $BUILD_TAG_PARAMETER
 
-HANDLER_PATH=pkg/uiserver/embedded_assets_handler.go
+HANDLER_PATH=$PROJECT_DIR/pkg/uiserver/embedded_assets_handler.go
 mv assets_vfsdata.go $HANDLER_PATH
 echo "  - Assets handler written to $HANDLER_PATH"

--- a/scripts/generate_assets.go
+++ b/scripts/generate_assets.go
@@ -12,11 +12,12 @@ import (
 )
 
 func main() {
-	buildTag := ""
-	if len(os.Args) > 1 {
-		buildTag = os.Args[1]
+	if len(os.Args) < 2 {
+		log.Fatal("Require 2 args")
 	}
-	var fs http.FileSystem = http.Dir("ui/build")
+	directory := os.Args[1]
+	buildTag := os.Args[2]
+	var fs http.FileSystem = http.Dir(directory)
 	err := vfsgen.Generate(fs, vfsgen.Options{
 		BuildTags:    buildTag,
 		PackageName:  "uiserver",


### PR DESCRIPTION
The root cause is that, as we are now introducing `go.mod` to the `scripts` directory, `go run` must run inside that directory in order to use its go.mod.