### PR TITLE
fix(distro): check distro_strings.json fmt by prettier

### DIFF
--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -2,3 +2,4 @@ build/
 public/
 lib/client/api/*.ts
 tsconfig.json
+distro_strings.json

--- a/ui/lib/distro_strings.json
+++ b/ui/lib/distro_strings.json
@@ -1,1 +1,1 @@
-{ "tidb": "TiDB", "tikv": "TiKV", "pd": "PD", "tiflash": "TiFlash" }
+{"tidb":"TiDB","tikv":"TiKV","pd":"PD","tiflash":"TiFlash"}


### PR DESCRIPTION
Since the distro_strings.json is generated by scripts when dev, there is no need for prettier to check and fmt.