### PR TITLE
fix generate assets

### DIFF
--- a/scripts/embed_ui_assets.sh
+++ b/scripts/embed_ui_assets.sh
@@ -32,7 +32,7 @@ fi
 echo "+ Embed UI assets"
 
 cd "$PROJECT_DIR/scripts"
-go run generate_assets.go "$PROJECT_DIR/ui/build" $BUILD_TAG_PARAMETER
+go run generate_assets.go "$PROJECT_DIR/ui/build" "$BUILD_TAG_PARAMETER"
 
 HANDLER_PATH=$PROJECT_DIR/pkg/uiserver/embedded_assets_handler.go
 mv assets_vfsdata.go $HANDLER_PATH

--- a/scripts/embed_ui_assets.sh
+++ b/scripts/embed_ui_assets.sh
@@ -32,7 +32,7 @@ fi
 echo "+ Embed UI assets"
 
 cd "$PROJECT_DIR/scripts"
-go run generate_assets.go "$PROJECT_DIR/ui/build" $BUILD_TAG_PARAMETER
+go run generate_assets.go "$PROJECT_DIR/ui/build" $BUILD_TAG_PARAMETER 
 
 HANDLER_PATH=$PROJECT_DIR/pkg/uiserver/embedded_assets_handler.go
 mv assets_vfsdata.go $HANDLER_PATH

--- a/scripts/embed_ui_assets.sh
+++ b/scripts/embed_ui_assets.sh
@@ -32,7 +32,7 @@ fi
 echo "+ Embed UI assets"
 
 cd "$PROJECT_DIR/scripts"
-go run generate_assets.go "$PROJECT_DIR/ui/build" $BUILD_TAG_PARAMETER 
+go run generate_assets.go "$PROJECT_DIR/ui/build" $BUILD_TAG_PARAMETER
 
 HANDLER_PATH=$PROJECT_DIR/pkg/uiserver/embedded_assets_handler.go
 mv assets_vfsdata.go $HANDLER_PATH

--- a/scripts/generate_assets.go
+++ b/scripts/generate_assets.go
@@ -16,7 +16,10 @@ func main() {
 		log.Fatal("Require 2 args")
 	}
 	directory := os.Args[1]
-	buildTag := os.Args[2]
+	buildTag := ""
+	if len(os.Args) > 2 {
+		buildTag = os.Args[2]
+	}
 	var fs http.FileSystem = http.Dir(directory)
 	err := vfsgen.Generate(fs, vfsgen.Options{
 		BuildTags:    buildTag,

--- a/scripts/generate_assets.go
+++ b/scripts/generate_assets.go
@@ -12,14 +12,11 @@ import (
 )
 
 func main() {
-	if len(os.Args) < 2 {
+	if len(os.Args) < 3 {
 		log.Fatal("Require 2 args")
 	}
 	directory := os.Args[1]
-	buildTag := ""
-	if len(os.Args) > 2 {
-		buildTag = os.Args[2]
-	}
+	buildTag := os.Args[2]
 	var fs http.FileSystem = http.Dir(directory)
 	err := vfsgen.Generate(fs, vfsgen.Options{
 		BuildTags:    buildTag,


### PR DESCRIPTION
What did:

- Fix `scripts/generate_assets.go` crash when building by `DASHBOARD=COMPILE make pd-server` in pd repo