### PR TITLE
fix: select slowquery from slowquery table

### DIFF
--- a/pkg/apiserver/slowquery/service.go
+++ b/pkg/apiserver/slowquery/service.go
@@ -94,7 +94,7 @@ func (s *Service) getDetails(c *gin.Context) {
 	}
 
 	db := utils.GetTiDBConnection(c)
-	result, err := QuerySlowLogDetail(&req, db)
+	result, err := QuerySlowLogDetail(&req, db.Table(SlowQueryTable))
 	if err != nil {
 		_ = c.Error(err)
 		return


### PR DESCRIPTION
Query slowquery detail will return: `No database selected`
This bug was introduced by add integration test:
https://github.com/pingcap/tidb-dashboard/pull/1083/files#diff-d0511bdf3eb8b77043a7cb8623422847e3e3d5dc5c033dbd63616a52cd8b1131L107-L108
https://github.com/pingcap/tidb-dashboard/pull/1083/files#diff-0a7ec858724330a3973a9ecac7cfa0699ca7d5c6231b5e68d4207d8331fadff0R97-R98