### PR TITLE
fix: ignore override tidb endpoint when profiling

### DIFF
--- a/pkg/apiserver/profiling/fetcher.go
+++ b/pkg/apiserver/profiling/fetcher.go
@@ -81,7 +81,7 @@ type tidbFetcher struct {
 }
 
 func (f *tidbFetcher) fetch(op *fetchOptions) ([]byte, error) {
-	return f.client.WithStatusAPIAddress(op.ip, op.port).WithStatusAPITimeout(maxProfilingTimeout).SendGetRequest(op.path)
+	return f.client.WithEnforcedStatusAPIAddress(op.ip, op.port).WithStatusAPITimeout(maxProfilingTimeout).SendGetRequest(op.path)
 }
 
 type pdFetcher struct {


### PR DESCRIPTION
We need to ignore `TIDB_OVERRIDE_STATUS_ENDPOINT` env var when profiling so that we can profile the correct target even if `TIDB_OVERRIDE_STATUS_ENDPOINT` is set.