### PR TITLE
fix: add a slash (/) before the hashtag for cross browser compatibility.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,4 +60,4 @@ linters-settings:
       - "^\\s*@"
   goheader:
     template: |-
-      Copyright {{ YEAR }} PingCAP, Inc. Licensed under Apache-2.0.
+      Copyright {{ YEAR-RANGE }} PingCAP, Inc. Licensed under Apache-2.0.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,4 +60,4 @@ linters-settings:
       - "^\\s*@"
   goheader:
     template: |-
-      Copyright {{ YEAR-RANGE }} PingCAP, Inc. Licensed under Apache-2.0.
+      Copyright {{ YEAR }} PingCAP, Inc. Licensed under Apache-2.0.

--- a/ui/lib/apps/ContinuousProfiling/pages/Detail.tsx
+++ b/ui/lib/apps/ContinuousProfiling/pages/Detail.tsx
@@ -67,13 +67,15 @@ export default function Page() {
         }
       })
 
-      newGroups.push({
-        key: InstanceKindName[instanceKind],
-        name: InstanceKindName[instanceKind],
-        startIndex: startIndex,
-        count: newRows.length - startIndex,
-      })
-      startIndex = newRows.length
+      if (newRows.length - startIndex > 0) {
+        newGroups.push({
+          key: InstanceKindName[instanceKind],
+          name: InstanceKindName[instanceKind],
+          startIndex: startIndex,
+          count: newRows.length - startIndex,
+        })
+        startIndex = newRows.length
+      }
     }
 
     return [newRows, newGroups]

--- a/ui/lib/apps/InstanceProfiling/pages/Detail.tsx
+++ b/ui/lib/apps/InstanceProfiling/pages/Detail.tsx
@@ -145,13 +145,15 @@ export default function Page() {
         }
       })
 
-      newGroups.push({
-        key: InstanceKindName[instanceKind],
-        name: InstanceKindName[instanceKind],
-        startIndex: startIndex,
-        count: newRows.length - startIndex,
-      })
-      startIndex = newRows.length
+      if (newRows.length - startIndex > 0) {
+        newGroups.push({
+          key: InstanceKindName[instanceKind],
+          name: InstanceKindName[instanceKind],
+          startIndex: startIndex,
+          count: newRows.length - startIndex,
+        })
+        startIndex = newRows.length
+      }
     }
     return [newRows, newGroups]
   }, [data])
@@ -178,7 +180,7 @@ export default function Page() {
         profileURL = `${client.getBasePath()}/profiling/single/view?token=${token}`
         if (isProtobuf) {
           const titleOnTab = rec.target?.kind + '_' + rec.target?.display_name
-          profileURL = `${publicPathPrefix}/speedscope#profileURL=${encodeURIComponent(
+          profileURL = `${publicPathPrefix}/speedscope/#profileURL=${encodeURIComponent(
             // protobuf can be rendered to flamegraph by speedscope
             profileURL + `&output_type=protobuf`
           )}&title=${titleOnTab}`


### PR DESCRIPTION
What this PR did?

1. Remove extra rows for instances with empty tasks.
![image](https://user-images.githubusercontent.com/34967660/148017154-0261c05b-10df-4847-98f0-01fa4bddc5ba.png)

2. There is a cross browser compatibility about hashtag. The profile URL with hashtag works unstable on safari. Sometimes different profile URLs load the same speedscope page, which is the previous loaded speedscope page.  The URL with tashtag has following behaviors on different browsers:

    `www.example.com#item`: this hashtag works fine on firefox and chrome, but work unstable on safari.
    `www.example.com/#item`: url with a back slash before hashtag works fine on firefox, chrome and safari.

      This issue can also be referred [here](https://stackoverflow.com/questions/18663410/safari-ignoring-removing-anchors-or-hashtags-when-clicking-hyperlinks/24778997#24778997)
