### PR TITLE
chore: update copyright to 2022

### DIFF
--- a/cmd/tidb-dashboard/main.go
+++ b/cmd/tidb-dashboard/main.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // @title Dashboard API
 // @version 1.0

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package apiserver
 

--- a/pkg/apiserver/clusterinfo/host.go
+++ b/pkg/apiserver/clusterinfo/host.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package clusterinfo
 

--- a/pkg/apiserver/clusterinfo/hostinfo/cluster_config.go
+++ b/pkg/apiserver/clusterinfo/hostinfo/cluster_config.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package hostinfo
 

--- a/pkg/apiserver/clusterinfo/hostinfo/cluster_hardware.go
+++ b/pkg/apiserver/clusterinfo/hostinfo/cluster_hardware.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package hostinfo
 

--- a/pkg/apiserver/clusterinfo/hostinfo/cluster_load.go
+++ b/pkg/apiserver/clusterinfo/hostinfo/cluster_load.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package hostinfo
 

--- a/pkg/apiserver/clusterinfo/hostinfo/hostinfo.go
+++ b/pkg/apiserver/clusterinfo/hostinfo/hostinfo.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package hostinfo
 

--- a/pkg/apiserver/clusterinfo/service.go
+++ b/pkg/apiserver/clusterinfo/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // clusterinfo is a directory for ClusterInfoServer, which could load topology from pd
 // using Etcd v3 interface and pd interface.

--- a/pkg/apiserver/clusterinfo/statistics.go
+++ b/pkg/apiserver/clusterinfo/statistics.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package clusterinfo
 

--- a/pkg/apiserver/clusterinfo/topology.go
+++ b/pkg/apiserver/clusterinfo/topology.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package clusterinfo
 

--- a/pkg/apiserver/configuration/editable.go
+++ b/pkg/apiserver/configuration/editable.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package configuration
 

--- a/pkg/apiserver/configuration/flatten.go
+++ b/pkg/apiserver/configuration/flatten.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package configuration
 

--- a/pkg/apiserver/configuration/router.go
+++ b/pkg/apiserver/configuration/router.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package configuration
 

--- a/pkg/apiserver/configuration/service.go
+++ b/pkg/apiserver/configuration/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package configuration
 

--- a/pkg/apiserver/conprof/module.go
+++ b/pkg/apiserver/conprof/module.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package conprof
 

--- a/pkg/apiserver/conprof/service.go
+++ b/pkg/apiserver/conprof/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // conprof is short for continuous profiling
 package conprof

--- a/pkg/apiserver/debugapi/apis.go
+++ b/pkg/apiserver/debugapi/apis.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package debugapi
 

--- a/pkg/apiserver/debugapi/endpoint/1_main_test.go
+++ b/pkg/apiserver/debugapi/endpoint/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package endpoint
 

--- a/pkg/apiserver/debugapi/endpoint/errors.go
+++ b/pkg/apiserver/debugapi/endpoint/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package endpoint
 

--- a/pkg/apiserver/debugapi/endpoint/models.go
+++ b/pkg/apiserver/debugapi/endpoint/models.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package endpoint
 

--- a/pkg/apiserver/debugapi/endpoint/models_test.go
+++ b/pkg/apiserver/debugapi/endpoint/models_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package endpoint
 

--- a/pkg/apiserver/debugapi/endpoint/payload.go
+++ b/pkg/apiserver/debugapi/endpoint/payload.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package endpoint
 

--- a/pkg/apiserver/debugapi/endpoint/payload_test.go
+++ b/pkg/apiserver/debugapi/endpoint/payload_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package endpoint
 

--- a/pkg/apiserver/debugapi/module.go
+++ b/pkg/apiserver/debugapi/module.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package debugapi
 

--- a/pkg/apiserver/debugapi/service.go
+++ b/pkg/apiserver/debugapi/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package debugapi
 

--- a/pkg/apiserver/diagnose/compare.go
+++ b/pkg/apiserver/diagnose/compare.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package diagnose
 

--- a/pkg/apiserver/diagnose/diagnose.go
+++ b/pkg/apiserver/diagnose/diagnose.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package diagnose
 

--- a/pkg/apiserver/diagnose/inspection.go
+++ b/pkg/apiserver/diagnose/inspection.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package diagnose
 

--- a/pkg/apiserver/diagnose/model.go
+++ b/pkg/apiserver/diagnose/model.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package diagnose
 

--- a/pkg/apiserver/diagnose/query.go
+++ b/pkg/apiserver/diagnose/query.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package diagnose
 

--- a/pkg/apiserver/diagnose/report.go
+++ b/pkg/apiserver/diagnose/report.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package diagnose
 

--- a/pkg/apiserver/diagnose/report_test.go
+++ b/pkg/apiserver/diagnose/report_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package diagnose
 

--- a/pkg/apiserver/info/info.go
+++ b/pkg/apiserver/info/info.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package info
 
@@ -62,7 +62,7 @@ func RegisterRouter(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 	endpoint.GET("/tables", s.tablesHandler)
 }
 
-type InfoResponse struct { //nolint
+type InfoResponse struct { // nolint
 	Version            *version.Info  `json:"version"`
 	EnableTelemetry    bool           `json:"enable_telemetry"`
 	EnableExperimental bool           `json:"enable_experimental"`

--- a/pkg/apiserver/logsearch/models.go
+++ b/pkg/apiserver/logsearch/models.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package logsearch
 

--- a/pkg/apiserver/logsearch/pack.go
+++ b/pkg/apiserver/logsearch/pack.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package logsearch
 

--- a/pkg/apiserver/logsearch/scheduler.go
+++ b/pkg/apiserver/logsearch/scheduler.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package logsearch
 

--- a/pkg/apiserver/logsearch/service.go
+++ b/pkg/apiserver/logsearch/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package logsearch
 

--- a/pkg/apiserver/logsearch/task.go
+++ b/pkg/apiserver/logsearch/task.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package logsearch
 

--- a/pkg/apiserver/metrics/prom_resolve.go
+++ b/pkg/apiserver/metrics/prom_resolve.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package metrics
 

--- a/pkg/apiserver/metrics/router.go
+++ b/pkg/apiserver/metrics/router.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package metrics
 

--- a/pkg/apiserver/metrics/service.go
+++ b/pkg/apiserver/metrics/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package metrics
 

--- a/pkg/apiserver/model/common_models.go
+++ b/pkg/apiserver/model/common_models.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package model
 

--- a/pkg/apiserver/profiling/fetcher.go
+++ b/pkg/apiserver/profiling/fetcher.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package profiling
 

--- a/pkg/apiserver/profiling/model.go
+++ b/pkg/apiserver/profiling/model.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package profiling
 

--- a/pkg/apiserver/profiling/module.go
+++ b/pkg/apiserver/profiling/module.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package profiling
 

--- a/pkg/apiserver/profiling/pprof.go
+++ b/pkg/apiserver/profiling/pprof.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package profiling
 

--- a/pkg/apiserver/profiling/profile.go
+++ b/pkg/apiserver/profiling/profile.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package profiling
 

--- a/pkg/apiserver/profiling/protobuf_to_svg.go
+++ b/pkg/apiserver/profiling/protobuf_to_svg.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package profiling
 

--- a/pkg/apiserver/profiling/router.go
+++ b/pkg/apiserver/profiling/router.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package profiling
 

--- a/pkg/apiserver/profiling/service.go
+++ b/pkg/apiserver/profiling/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package profiling
 

--- a/pkg/apiserver/queryeditor/service.go
+++ b/pkg/apiserver/queryeditor/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package queryeditor
 

--- a/pkg/apiserver/slowquery/model.go
+++ b/pkg/apiserver/slowquery/model.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package slowquery
 

--- a/pkg/apiserver/slowquery/module.go
+++ b/pkg/apiserver/slowquery/module.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package slowquery
 

--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package slowquery
 

--- a/pkg/apiserver/slowquery/service.go
+++ b/pkg/apiserver/slowquery/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package slowquery
 

--- a/pkg/apiserver/slowquery/statement_gen.go
+++ b/pkg/apiserver/slowquery/statement_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package slowquery
 

--- a/pkg/apiserver/statement/config.go
+++ b/pkg/apiserver/statement/config.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package statement
 

--- a/pkg/apiserver/statement/config_test.go
+++ b/pkg/apiserver/statement/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package statement
 

--- a/pkg/apiserver/statement/models.go
+++ b/pkg/apiserver/statement/models.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package statement
 

--- a/pkg/apiserver/statement/module.go
+++ b/pkg/apiserver/statement/module.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package statement
 

--- a/pkg/apiserver/statement/queries.go
+++ b/pkg/apiserver/statement/queries.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package statement
 

--- a/pkg/apiserver/statement/service.go
+++ b/pkg/apiserver/statement/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package statement
 

--- a/pkg/apiserver/statement/statement_gen.go
+++ b/pkg/apiserver/statement/statement_gen.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package statement
 

--- a/pkg/apiserver/topsql/module.go
+++ b/pkg/apiserver/topsql/module.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topsql
 

--- a/pkg/apiserver/topsql/service.go
+++ b/pkg/apiserver/topsql/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topsql
 

--- a/pkg/apiserver/user/auth.go
+++ b/pkg/apiserver/user/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package user
 

--- a/pkg/apiserver/user/code/codeauth/auth.go
+++ b/pkg/apiserver/user/code/codeauth/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package codeauth
 

--- a/pkg/apiserver/user/code/router.go
+++ b/pkg/apiserver/user/code/router.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package code
 

--- a/pkg/apiserver/user/code/service.go
+++ b/pkg/apiserver/user/code/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package code
 

--- a/pkg/apiserver/user/module.go
+++ b/pkg/apiserver/user/module.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package user
 

--- a/pkg/apiserver/user/sqlauth/sqlauth.go
+++ b/pkg/apiserver/user/sqlauth/sqlauth.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package sqlauth
 

--- a/pkg/apiserver/user/sso/models.go
+++ b/pkg/apiserver/user/sso/models.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package sso
 
@@ -14,7 +14,7 @@ const (
 	ImpersonateStatusInsufficientPrivs ImpersonateStatus = "insufficient_privileges"
 )
 
-type SSOImpersonationModel struct { //nolint
+type SSOImpersonationModel struct { // nolint
 	SQLUser string `gorm:"primary_key;size:128" json:"sql_user"`
 	// The encryption key is placed somewhere else in the FS, to avoid being collected by diagnostics collecting tools.
 	EncryptedPass         string             `gorm:"type:text" json:"-"`

--- a/pkg/apiserver/user/sso/router.go
+++ b/pkg/apiserver/user/sso/router.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package sso
 

--- a/pkg/apiserver/user/sso/service.go
+++ b/pkg/apiserver/user/sso/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package sso
 

--- a/pkg/apiserver/user/sso/ssoauth/auth.go
+++ b/pkg/apiserver/user/sso/ssoauth/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package ssoauth
 

--- a/pkg/apiserver/user/verify_sql_user.go
+++ b/pkg/apiserver/user/verify_sql_user.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package user
 

--- a/pkg/apiserver/user/verify_sql_user_test.go
+++ b/pkg/apiserver/user/verify_sql_user_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package user
 

--- a/pkg/apiserver/utils/auth.go
+++ b/pkg/apiserver/utils/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/apiserver/utils/error.go
+++ b/pkg/apiserver/utils/error.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/apiserver/utils/export.go
+++ b/pkg/apiserver/utils/export.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/apiserver/utils/gorm.go
+++ b/pkg/apiserver/utils/gorm.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/apiserver/utils/gorm_test.go
+++ b/pkg/apiserver/utils/gorm_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/apiserver/utils/jwt.go
+++ b/pkg/apiserver/utils/jwt.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/apiserver/utils/mw_experimental.go
+++ b/pkg/apiserver/utils/mw_experimental.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/apiserver/utils/ngm.go
+++ b/pkg/apiserver/utils/ngm.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/apiserver/utils/subset.go
+++ b/pkg/apiserver/utils/subset.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/apiserver/utils/tidb_conn.go
+++ b/pkg/apiserver/utils/tidb_conn.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package config
 

--- a/pkg/config/dynamic_config.go
+++ b/pkg/config/dynamic_config.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package config
 

--- a/pkg/config/dynamic_config_manager.go
+++ b/pkg/config/dynamic_config_manager.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package config
 

--- a/pkg/dbstore/dbstore.go
+++ b/pkg/dbstore/dbstore.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package dbstore
 

--- a/pkg/httpc/client.go
+++ b/pkg/httpc/client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package httpc
 

--- a/pkg/httpc/client_test.go
+++ b/pkg/httpc/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package httpc
 

--- a/pkg/keyvisual/decorator/decorator.go
+++ b/pkg/keyvisual/decorator/decorator.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Package decorator contains all implementations of LabelStrategy.
 package decorator

--- a/pkg/keyvisual/decorator/decorator_test.go
+++ b/pkg/keyvisual/decorator/decorator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package decorator
 

--- a/pkg/keyvisual/decorator/separator.go
+++ b/pkg/keyvisual/decorator/separator.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package decorator
 

--- a/pkg/keyvisual/decorator/tidb.go
+++ b/pkg/keyvisual/decorator/tidb.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package decorator
 

--- a/pkg/keyvisual/decorator/tidb_requests.go
+++ b/pkg/keyvisual/decorator/tidb_requests.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package decorator
 

--- a/pkg/keyvisual/decorator/tidb_test.go
+++ b/pkg/keyvisual/decorator/tidb_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package decorator
 

--- a/pkg/keyvisual/input/api.go
+++ b/pkg/keyvisual/input/api.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package input
 

--- a/pkg/keyvisual/input/file.go
+++ b/pkg/keyvisual/input/file.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package input
 

--- a/pkg/keyvisual/input/input.go
+++ b/pkg/keyvisual/input/input.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Package input defines several different data inputs.
 package input

--- a/pkg/keyvisual/input/periodic.go
+++ b/pkg/keyvisual/input/periodic.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package input
 

--- a/pkg/keyvisual/manager.go
+++ b/pkg/keyvisual/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package keyvisual
 

--- a/pkg/keyvisual/matrix/average.go
+++ b/pkg/keyvisual/matrix/average.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/average_test.go
+++ b/pkg/keyvisual/matrix/average_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/axis.go
+++ b/pkg/keyvisual/matrix/axis.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/axis_test.go
+++ b/pkg/keyvisual/matrix/axis_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/distance.go
+++ b/pkg/keyvisual/matrix/distance.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/distance_test.go
+++ b/pkg/keyvisual/matrix/distance_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/interface.go
+++ b/pkg/keyvisual/matrix/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/key.go
+++ b/pkg/keyvisual/matrix/key.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/key_test.go
+++ b/pkg/keyvisual/matrix/key_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/matrix.go
+++ b/pkg/keyvisual/matrix/matrix.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Package matrix abstracts the source data as Plane, and then pixelates it into a matrix for display on the front end.
 package matrix

--- a/pkg/keyvisual/matrix/matrix_test.go
+++ b/pkg/keyvisual/matrix/matrix_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/plane.go
+++ b/pkg/keyvisual/matrix/plane.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/plane_test.go
+++ b/pkg/keyvisual/matrix/plane_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/util.go
+++ b/pkg/keyvisual/matrix/util.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/matrix/util_test.go
+++ b/pkg/keyvisual/matrix/util_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package matrix
 

--- a/pkg/keyvisual/region/interface.go
+++ b/pkg/keyvisual/region/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package region
 

--- a/pkg/keyvisual/region/tag.go
+++ b/pkg/keyvisual/region/tag.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package region
 

--- a/pkg/keyvisual/region/utils.go
+++ b/pkg/keyvisual/region/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package region
 

--- a/pkg/keyvisual/service.go
+++ b/pkg/keyvisual/service.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package keyvisual
 

--- a/pkg/keyvisual/storage/model.go
+++ b/pkg/keyvisual/storage/model.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package storage
 

--- a/pkg/keyvisual/storage/model_test.go
+++ b/pkg/keyvisual/storage/model_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package storage
 

--- a/pkg/keyvisual/storage/region.go
+++ b/pkg/keyvisual/storage/region.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package storage
 

--- a/pkg/keyvisual/storage/region_test.go
+++ b/pkg/keyvisual/storage/region_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package storage
 

--- a/pkg/keyvisual/storage/stat.go
+++ b/pkg/keyvisual/storage/stat.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Package storage stores the input axes in order, and can get a Plane by time interval.
 package storage

--- a/pkg/keyvisual/storage/stat_persist.go
+++ b/pkg/keyvisual/storage/stat_persist.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package storage
 

--- a/pkg/keyvisual/storage/stat_test.go
+++ b/pkg/keyvisual/storage/stat_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package storage
 

--- a/pkg/pd/client.go
+++ b/pkg/pd/client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pd
 

--- a/pkg/pd/client_test.go
+++ b/pkg/pd/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pd
 

--- a/pkg/pd/etcd.go
+++ b/pkg/pd/etcd.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pd
 

--- a/pkg/pd/pd.go
+++ b/pkg/pd/pd.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pd
 

--- a/pkg/swaggerserver/handler.go
+++ b/pkg/swaggerserver/handler.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package swaggerserver
 

--- a/pkg/tidb/client.go
+++ b/pkg/tidb/client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tidb
 

--- a/pkg/tidb/forwarder.go
+++ b/pkg/tidb/forwarder.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tidb
 

--- a/pkg/tidb/model/codec.go
+++ b/pkg/tidb/model/codec.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package model
 

--- a/pkg/tidb/model/codec_test.go
+++ b/pkg/tidb/model/codec_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package model
 

--- a/pkg/tidb/model/model.go
+++ b/pkg/tidb/model/model.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package model
 

--- a/pkg/tidb/proxy.go
+++ b/pkg/tidb/proxy.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tidb
 
@@ -112,12 +112,12 @@ func (p *proxy) serve(in net.Conn) {
 	}
 	// bidirectional copy
 	go func() {
-		//nolint
+		// nolint
 		io.Copy(in, out)
 		_ = in.Close()
 		_ = out.Close()
 	}()
-	//nolint
+	// nolint
 	io.Copy(out, in)
 	_ = out.Close()
 	_ = in.Close()

--- a/pkg/tidb/proxy_test.go
+++ b/pkg/tidb/proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tidb
 

--- a/pkg/tidb/tidb.go
+++ b/pkg/tidb/tidb.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tidb
 

--- a/pkg/tiflash/client.go
+++ b/pkg/tiflash/client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tiflash
 

--- a/pkg/tiflash/tiflash.go
+++ b/pkg/tiflash/tiflash.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tiflash
 

--- a/pkg/tikv/client.go
+++ b/pkg/tikv/client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tikv
 

--- a/pkg/tikv/tikv.go
+++ b/pkg/tikv/tikv.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tikv
 

--- a/pkg/uiserver/embedded_assets_rewriter.go
+++ b/pkg/uiserver/embedded_assets_rewriter.go
@@ -1,5 +1,6 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
+//go:build ui_server
 // +build ui_server
 
 package uiserver

--- a/pkg/uiserver/empty_assets_handler.go
+++ b/pkg/uiserver/empty_assets_handler.go
@@ -1,5 +1,6 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
+//go:build !ui_server
 // +build !ui_server
 
 package uiserver

--- a/pkg/uiserver/uiserver.go
+++ b/pkg/uiserver/uiserver.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package uiserver
 

--- a/pkg/utils/fx.go
+++ b/pkg/utils/fx.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/utils/grpc.go
+++ b/pkg/utils/grpc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/utils/service_status.go
+++ b/pkg/utils/service_status.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/utils/sys_schema.go
+++ b/pkg/utils/sys_schema.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package utils
 

--- a/pkg/utils/topology/models.go
+++ b/pkg/utils/topology/models.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topology
 

--- a/pkg/utils/topology/monitor.go
+++ b/pkg/utils/topology/monitor.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topology
 

--- a/pkg/utils/topology/pd.go
+++ b/pkg/utils/topology/pd.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topology
 

--- a/pkg/utils/topology/store.go
+++ b/pkg/utils/topology/store.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topology
 

--- a/pkg/utils/topology/tidb.go
+++ b/pkg/utils/topology/tidb.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topology
 

--- a/pkg/utils/topology/topology.go
+++ b/pkg/utils/topology/topology.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topology
 

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package version
 

--- a/scripts/distro/write_strings.go
+++ b/scripts/distro/write_strings.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package main
 

--- a/scripts/generate_assets.go
+++ b/scripts/generate_assets.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package main
 

--- a/scripts/pd_version_matrix.go
+++ b/scripts/pd_version_matrix.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // This proram can be used to generate a version relationship matrix for TiDB Dashboard and PD.
 

--- a/scripts/tools.go
+++ b/scripts/tools.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package scripts
 

--- a/swaggerspec/placeholder.go
+++ b/swaggerspec/placeholder.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // This file only ensures `swaggerspec` package exist even if swagger is not enabled. This is required for `go mod tidy`.
 

--- a/tests/integration/diagnose_report_test.go
+++ b/tests/integration/diagnose_report_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package integration
 
@@ -17,7 +17,7 @@ var _ = Suite(&testReportSuite{})
 
 type testReportSuite struct{}
 
-//func (t *testReportSuite) TestReport(c *C) {
+// func (t *testReportSuite) TestReport(c *C) {
 //	cli, err := gorm.Open("mysql", "root:@tcp(172.16.5.40:4009)/test?charset=utf8&parseTime=True&loc=Local")
 //	c.Assert(err, IsNil)
 //	defer cli.Close()
@@ -29,7 +29,7 @@ type testReportSuite struct{}
 //	for _, tbl := range tables {
 //		printRows(tbl)
 //	}
-//}
+// }
 
 // func (t *testReportSuite) TestGetTable(c *C) {
 // 	cli, err := gorm.Open(mysql.Open("root:@tcp(172.16.5.40:4009)/test?charset=utf8&parseTime=True&loc=Local"))

--- a/tests/integration/slowquery/compatibility_test.go
+++ b/tests/integration/slowquery/compatibility_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package slowquery
 

--- a/tests/integration/slowquery/mock_db_test.go
+++ b/tests/integration/slowquery/mock_db_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package slowquery
 

--- a/tests/util/compatibility.go
+++ b/tests/util/compatibility.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package util
 

--- a/tests/util/dump/dump.go
+++ b/tests/util/dump/dump.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package main
 

--- a/tests/util/fixtures.go
+++ b/tests/util/fixtures.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package util
 

--- a/util/assertutil/1_main_test.go
+++ b/util/assertutil/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package assertutil
 

--- a/util/assertutil/json.go
+++ b/util/assertutil/json.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
 

--- a/util/assertutil/json_test.go
+++ b/util/assertutil/json_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package assertutil
 

--- a/util/assertutil/mock.go
+++ b/util/assertutil/mock.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
 

--- a/util/client/httpclient/1_main_test.go
+++ b/util/client/httpclient/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package httpclient
 

--- a/util/client/httpclient/client.go
+++ b/util/client/httpclient/client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Copyright (c) 2015-2021 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
 // resty source code and usage is governed by a MIT style

--- a/util/client/httpclient/config.go
+++ b/util/client/httpclient/config.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package httpclient
 

--- a/util/client/httpclient/info.go
+++ b/util/client/httpclient/info.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package httpclient
 

--- a/util/client/httpclient/request.go
+++ b/util/client/httpclient/request.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Copyright (c) 2015-2021 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
 // resty source code and usage is governed by a MIT style

--- a/util/client/httpclient/request_resty.go
+++ b/util/client/httpclient/request_resty.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Copyright (c) 2015-2021 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
 // resty source code and usage is governed by a MIT style

--- a/util/client/httpclient/response.go
+++ b/util/client/httpclient/response.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package httpclient
 

--- a/util/client/httpclient/response_test.go
+++ b/util/client/httpclient/response_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package httpclient
 

--- a/util/client/pdclient/1_main_test.go
+++ b/util/client/pdclient/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdclient_test
 

--- a/util/client/pdclient/etcd_client.go
+++ b/util/client/pdclient/etcd_client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdclient
 

--- a/util/client/pdclient/fixture/pd_server.go
+++ b/util/client/pdclient/fixture/pd_server.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package fixture
 

--- a/util/client/pdclient/pd_api.go
+++ b/util/client/pdclient/pd_api.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdclient
 

--- a/util/client/pdclient/pd_api_client.go
+++ b/util/client/pdclient/pd_api_client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Package pdclient provides a flexible PD API access to any PD instance.
 package pdclient

--- a/util/client/pdclient/pd_api_highlevel.go
+++ b/util/client/pdclient/pd_api_highlevel.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // This file contains high level encapsulations over base PD APIs.
 

--- a/util/client/pdclient/pd_api_highlevel_test.go
+++ b/util/client/pdclient/pd_api_highlevel_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdclient_test
 

--- a/util/client/pdclient/pd_api_test.go
+++ b/util/client/pdclient/pd_api_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdclient_test
 

--- a/util/client/tidbclient/sql_client.go
+++ b/util/client/tidbclient/sql_client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tidbclient
 

--- a/util/client/tidbclient/status_client.go
+++ b/util/client/tidbclient/status_client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Package tidbclient provides a flexible TiDB API access to any TiDB instance.
 package tidbclient

--- a/util/client/tidbclient/tidbproto/1_main_test.go
+++ b/util/client/tidbclient/tidbproto/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tidbproto
 

--- a/util/client/tidbclient/tidbproto/codec.go
+++ b/util/client/tidbclient/tidbproto/codec.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tidbproto
 

--- a/util/client/tidbclient/tidbproto/codec_test.go
+++ b/util/client/tidbclient/tidbproto/codec_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tidbproto
 

--- a/util/client/tidbclient/tidbproto/model.go
+++ b/util/client/tidbclient/tidbproto/model.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tidbproto
 

--- a/util/client/tidbclient/tidbproxy/proxy.go
+++ b/util/client/tidbclient/tidbproxy/proxy.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Package tidbproxy provides a TiDB cluster proxy service. It forwards incoming SQL API and
 // Status API requests to one of the alive TiDB upstream.

--- a/util/client/tiflashclient/status_client.go
+++ b/util/client/tiflashclient/status_client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Package tiflashclient provides a flexible TiFlash API access to any TiFlash instance.
 package tiflashclient

--- a/util/client/tikvclient/status_client.go
+++ b/util/client/tikvclient/status_client.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Package tikvclient provides a flexible TiKV API access to any TiKV instance.
 package tikvclient

--- a/util/csvutil/1_main_test.go
+++ b/util/csvutil/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package csvutil
 

--- a/util/csvutil/writer.go
+++ b/util/csvutil/writer.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package csvutil
 

--- a/util/csvutil/writer_test.go
+++ b/util/csvutil/writer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package csvutil
 

--- a/util/distro/1_main_test.go
+++ b/util/distro/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package distro
 

--- a/util/distro/distro.go
+++ b/util/distro/distro.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Package distro provides a type-safe distribution resource framework.
 // Distribution resource determines how component names are displayed in errors, logs and so on.

--- a/util/distro/distro_test.go
+++ b/util/distro/distro_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package distro
 

--- a/util/featureflag/1_main_test.go
+++ b/util/featureflag/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package featureflag
 

--- a/util/featureflag/featureflag.go
+++ b/util/featureflag/featureflag.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package featureflag
 

--- a/util/featureflag/featureflag_test.go
+++ b/util/featureflag/featureflag_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package featureflag
 

--- a/util/featureflag/registry.go
+++ b/util/featureflag/registry.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package featureflag
 

--- a/util/featureflag/registry_test.go
+++ b/util/featureflag/registry_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package featureflag
 

--- a/util/fxprinter/fxprinter.go
+++ b/util/fxprinter/fxprinter.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package fxprinter
 

--- a/util/gormutil/datatype/1_main_test.go
+++ b/util/gormutil/datatype/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package datatype
 

--- a/util/gormutil/datatype/int.go
+++ b/util/gormutil/datatype/int.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package datatype
 

--- a/util/gormutil/datatype/int_test.go
+++ b/util/gormutil/datatype/int_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package datatype
 

--- a/util/gormutil/datatype/int_withdb_test.go
+++ b/util/gormutil/datatype/int_withdb_test.go
@@ -1,5 +1,6 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
+//go:build integration
 // +build integration
 
 package datatype

--- a/util/gormutil/datatype/nullable/nullable.go
+++ b/util/gormutil/datatype/nullable/nullable.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package nullable
 

--- a/util/gormutil/datatype/timestamp.go
+++ b/util/gormutil/datatype/timestamp.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package datatype
 

--- a/util/gormutil/datatype/timestamp_test.go
+++ b/util/gormutil/datatype/timestamp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package datatype
 

--- a/util/gormutil/datatype/timestamp_withdb_test.go
+++ b/util/gormutil/datatype/timestamp_withdb_test.go
@@ -1,5 +1,6 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
+//go:build integration
 // +build integration
 
 package datatype

--- a/util/gormutil/virtualview/1_main_test.go
+++ b/util/gormutil/virtualview/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package virtualview
 

--- a/util/gormutil/virtualview/schema.go
+++ b/util/gormutil/virtualview/schema.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package virtualview
 

--- a/util/gormutil/virtualview/schema_test.go
+++ b/util/gormutil/virtualview/schema_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package virtualview
 

--- a/util/gormutil/virtualview/virtualview.go
+++ b/util/gormutil/virtualview/virtualview.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package virtualview
 

--- a/util/gormutil/virtualview/virtualview_test.go
+++ b/util/gormutil/virtualview/virtualview_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package virtualview
 

--- a/util/israce/no_race.go
+++ b/util/israce/no_race.go
@@ -1,5 +1,6 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
+//go:build !race
 // +build !race
 
 // Package israce reports if the Go race detector is enabled.

--- a/util/israce/race.go
+++ b/util/israce/race.go
@@ -1,5 +1,6 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
+//go:build race
 // +build race
 
 // Package israce reports if the Go race detector is enabled.

--- a/util/lifecyclectx/fx.go
+++ b/util/lifecyclectx/fx.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package lifecyclectx
 

--- a/util/lifecyclectx/lifecyclectxtest/test.go
+++ b/util/lifecyclectx/lifecyclectxtest/test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package lifecyclectxtest
 

--- a/util/netutil/1_main_test.go
+++ b/util/netutil/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package netutil
 

--- a/util/netutil/parse.go
+++ b/util/netutil/parse.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package netutil
 

--- a/util/netutil/parse_test.go
+++ b/util/netutil/parse_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package netutil
 

--- a/util/nocopy/nocopy.go
+++ b/util/nocopy/nocopy.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package nocopy
 

--- a/util/proxy/1_main_test.go
+++ b/util/proxy/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package proxy
 

--- a/util/proxy/proxy.go
+++ b/util/proxy/proxy.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 // Package proxy provides a TCP reverse proxy. Unlike normal reverse proxy, the upstream is intentionally fixed.
 // A new upstream will be selected if the current upstream is down.

--- a/util/proxy/proxy_test.go
+++ b/util/proxy/proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package proxy
 

--- a/util/proxy/upstream.go
+++ b/util/proxy/upstream.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package proxy
 

--- a/util/reflectutil/1_main_test.go
+++ b/util/reflectutil/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package reflectutil
 

--- a/util/reflectutil/field.go
+++ b/util/reflectutil/field.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package reflectutil
 

--- a/util/reflectutil/field_test.go
+++ b/util/reflectutil/field_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package reflectutil
 

--- a/util/reflectutil/tag.go
+++ b/util/reflectutil/tag.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package reflectutil
 

--- a/util/reflectutil/tag_test.go
+++ b/util/reflectutil/tag_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package reflectutil
 

--- a/util/rest/1_main_test.go
+++ b/util/rest/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package rest
 

--- a/util/rest/empty_resp.go
+++ b/util/rest/empty_resp.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package rest
 

--- a/util/rest/error.go
+++ b/util/rest/error.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package rest
 

--- a/util/rest/error_resp.go
+++ b/util/rest/error_resp.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package rest
 

--- a/util/rest/error_resp_test.go
+++ b/util/rest/error_resp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package rest
 

--- a/util/rest/error_test.go
+++ b/util/rest/error_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package rest
 

--- a/util/rest/fileswap/1_main_test.go
+++ b/util/rest/fileswap/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package fileswap
 

--- a/util/rest/fileswap/server.go
+++ b/util/rest/fileswap/server.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package fileswap
 

--- a/util/rest/fileswap/server_test.go
+++ b/util/rest/fileswap/server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package fileswap
 

--- a/util/sqlitestore/sqlitestore.go
+++ b/util/sqlitestore/sqlitestore.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package dbstore
 

--- a/util/testutil/db.go
+++ b/util/testutil/db.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package testutil
 

--- a/util/testutil/http_server.go
+++ b/util/testutil/http_server.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package testutil
 

--- a/util/testutil/log.go
+++ b/util/testutil/log.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package testutil
 

--- a/util/testutil/testutil.go
+++ b/util/testutil/testutil.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package testutil
 

--- a/util/timeutil/1_main_test.go
+++ b/util/timeutil/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package timeutil
 

--- a/util/timeutil/format.go
+++ b/util/timeutil/format.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package timeutil
 

--- a/util/timeutil/format_test.go
+++ b/util/timeutil/format_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package timeutil
 

--- a/util/tlsutil/1_main_test.go
+++ b/util/tlsutil/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tlsutil
 

--- a/util/tlsutil/config_ext.go
+++ b/util/tlsutil/config_ext.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tlsutil
 

--- a/util/tlsutil/config_ext_test.go
+++ b/util/tlsutil/config_ext_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package tlsutil
 

--- a/util/topo/1_main_test.go
+++ b/util/topo/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topo
 

--- a/util/topo/models.go
+++ b/util/topo/models.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topo
 

--- a/util/topo/pdtopo/1_main_test.go
+++ b/util/topo/pdtopo/1_main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdtopo_test
 

--- a/util/topo/pdtopo/monitor.go
+++ b/util/topo/pdtopo/monitor.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdtopo
 

--- a/util/topo/pdtopo/pd.go
+++ b/util/topo/pdtopo/pd.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdtopo
 

--- a/util/topo/pdtopo/pd_test.go
+++ b/util/topo/pdtopo/pd_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdtopo_test
 

--- a/util/topo/pdtopo/provider_pd.go
+++ b/util/topo/pdtopo/provider_pd.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdtopo
 

--- a/util/topo/pdtopo/std_comp.go
+++ b/util/topo/pdtopo/std_comp.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdtopo
 

--- a/util/topo/pdtopo/store.go
+++ b/util/topo/pdtopo/store.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdtopo
 

--- a/util/topo/pdtopo/store_test.go
+++ b/util/topo/pdtopo/store_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdtopo_test
 

--- a/util/topo/pdtopo/tidb.go
+++ b/util/topo/pdtopo/tidb.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package pdtopo
 

--- a/util/topo/provider.go
+++ b/util/topo/provider.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topo
 

--- a/util/topo/provider_cached.go
+++ b/util/topo/provider_cached.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topo
 

--- a/util/topo/provider_cached_test.go
+++ b/util/topo/provider_cached_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package topo
 

--- a/util/ziputil/zip_writer.go
+++ b/util/ziputil/zip_writer.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package ziputil
 


### PR DESCRIPTION
This PR updates the copyright header to be year 2022.

This fixes the backend CI error discovered in https://github.com/pingcap/tidb-dashboard/pull/1123