### PR TITLE
chore(stmt): use common time range picker

### DIFF
--- a/ui/lib/apps/Statement/pages/List/index.tsx
+++ b/ui/lib/apps/Statement/pages/List/index.tsx
@@ -22,12 +22,17 @@ import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane'
 import { useTranslation } from 'react-i18next'
 
 import { CacheContext } from '@lib/utils/useCache'
-import { Card, ColumnsSelector, Toolbar, MultiSelect } from '@lib/components'
+import {
+  Card,
+  ColumnsSelector,
+  Toolbar,
+  MultiSelect,
+  TimeRangeSelector,
+} from '@lib/components'
 import { useLocalStorageState } from '@lib/utils/useLocalStorageState'
 
 import { StatementsTable } from '../../components'
 import StatementSettingForm from './StatementSettingForm'
-import TimeRangeSelector from './TimeRangeSelector'
 import useStatementTableController, {
   DEF_STMT_COLUMN_KEYS,
 } from '../../utils/useStatementTableController'
@@ -65,7 +70,6 @@ export default function StatementsOverview() {
     setQueryOptions,
     refresh,
     enable,
-    allTimeRanges,
     allSchemas,
     allStmtTypes,
     loadingStatements,
@@ -109,7 +113,6 @@ export default function StatementsOverview() {
           <Space>
             <TimeRangeSelector
               value={queryOptions.timeRange}
-              timeRanges={allTimeRanges}
               onChange={(timeRange) =>
                 setQueryOptions({
                   ...queryOptions,


### PR DESCRIPTION
According to user feedback, common time range picker may be easier to use. Any better ideas?

/cc @breeswish @baurine @lilyjazz

From:
![image](https://user-images.githubusercontent.com/11549583/148748333-407bac1a-71f5-4c42-9363-cd921cffddec.png)

To:
![image](https://user-images.githubusercontent.com/11549583/148748356-9b2910e1-d244-4856-b93b-d89c231b3daa.png)
