### PR TITLE
make more convinient for developing in the remote machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ endif
 
 .PHONY: run
 run:
-	bin/tidb-dashboard --debug --experimental --feature-version "$(FEATURE_VERSION)"
+	bin/tidb-dashboard --debug --experimental --feature-version "$(FEATURE_VERSION)" --host 0.0.0.0
 
 test_e2e_compat_features:
 	cd ui &&\

--- a/ui/lib/client/baseUrl.ts
+++ b/ui/lib/client/baseUrl.ts
@@ -6,7 +6,7 @@ export const API_HOST = (function getApiHost(): string {
     if (process.env.REACT_APP_DASHBOARD_API_URL) {
       apiPrefix = `${process.env.REACT_APP_DASHBOARD_API_URL}/dashboard`
     } else {
-      apiPrefix = 'http://127.0.0.1:12333/dashboard'
+      apiPrefix = `http://${window.location.hostname}:12333/dashboard`
     }
   } else {
     apiPrefix = publicPathPrefix


### PR DESCRIPTION
When a user develops TiDB dashboard in a remote machine and accesses the frontend page in the local, he will get the following error by accessing `http://{remote_addr}:3001/dashboard` in the local browser: 

![image](https://user-images.githubusercontent.com/1284531/148755485-b2ad7e22-31bd-49f7-86c4-270ebf5173ad.png)

Because the frontend can't access the backend API by `http://127.0.0.0:12333/dashboard/api`.

Solutions:

1. Forward local port 12333 to the remote, for example: `ssh -L 12333:locahost:12333 remote_addr`. 

1. Run TiDB dashboard backend by `bin/tidb-dashboard --host 0.0.0.0` and set `REACT_APP_DASHBOARD_API_URL=http://{remote_addr}:12333` in the `.env` file

1. Run TiDB dashboard backend by `bin/tidb-dashboard --host 0.0.0.0` and use `http://${window.location.hostname}:12333/dashboard` instead of `http://127.0.0.01:12333/dashboard` as API addr prefix.

This PR implements solution 3, and I think this would bring a little more convenience for the developers to develop in a remote machine.