### PR TITLE
refactor: introduce gin context helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/jarcoal/httpmock v1.0.8
 	github.com/joho/godotenv v1.4.0
 	github.com/joomcode/errorx v1.0.1
+	github.com/json-iterator/go v1.1.12
 	github.com/minio/sio v0.3.0
 	github.com/oleiade/reflections v1.0.1
 	github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,9 @@ github.com/joomcode/errorx v1.0.1/go.mod h1:kgco15ekB6cs+4Xjzo7SPeXzx38PbJzBwbnu
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -287,8 +288,9 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5 h1:BvoENQQU+fZ9uukda/RzCAL/191HHwJA5b13R6diVlY=
 github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=

--- a/pkg/apiserver/clusterinfo/service.go
+++ b/pkg/apiserver/clusterinfo/service.go
@@ -103,7 +103,7 @@ func (s *Service) deleteTiDBTopology(c *gin.Context) {
 	close(errorChannel)
 
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, nil)
@@ -118,7 +118,7 @@ func (s *Service) deleteTiDBTopology(c *gin.Context) {
 func (s *Service) getTiDBTopology(c *gin.Context) {
 	instances, err := topology.FetchTiDBTopology(s.lifecycleCtx, s.params.EtcdClient)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, instances)
@@ -138,7 +138,7 @@ type StoreTopologyResponse struct {
 func (s *Service) getStoreTopology(c *gin.Context) {
 	tikvInstances, tiFlashInstances, err := topology.FetchStoreTopology(s.params.PDClient)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, StoreTopologyResponse{
@@ -156,7 +156,7 @@ func (s *Service) getStoreTopology(c *gin.Context) {
 func (s *Service) getStoreLocationTopology(c *gin.Context) {
 	storeLocation, err := topology.FetchStoreLocation(s.params.PDClient)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, storeLocation)
@@ -171,7 +171,7 @@ func (s *Service) getStoreLocationTopology(c *gin.Context) {
 func (s *Service) getPDTopology(c *gin.Context) {
 	instances, err := topology.FetchPDTopology(s.params.PDClient)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, instances)
@@ -186,7 +186,7 @@ func (s *Service) getPDTopology(c *gin.Context) {
 func (s *Service) getAlertManagerTopology(c *gin.Context) {
 	instance, err := topology.FetchAlertManagerTopology(s.lifecycleCtx, s.params.EtcdClient)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, instance)
@@ -201,7 +201,7 @@ func (s *Service) getAlertManagerTopology(c *gin.Context) {
 func (s *Service) getGrafanaTopology(c *gin.Context) {
 	instance, err := topology.FetchGrafanaTopology(s.lifecycleCtx, s.params.EtcdClient)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, instance)
@@ -218,7 +218,7 @@ func (s *Service) getAlertManagerCounts(c *gin.Context) {
 	address := c.Param("address")
 	cnt, err := fetchAlertManagerCounts(s.lifecycleCtx, address, s.params.HTTPClient)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, cnt)
@@ -240,7 +240,7 @@ func (s *Service) getHostsInfo(c *gin.Context) {
 
 	info, err := s.fetchAllHostsInfo(db)
 	if err != nil && info == nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
@@ -265,7 +265,7 @@ func (s *Service) getStatistics(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	stats, err := s.calculateStatistics(db)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, stats)

--- a/pkg/apiserver/configuration/router.go
+++ b/pkg/apiserver/configuration/router.go
@@ -33,7 +33,7 @@ func (s *Service) getHandler(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	r, err := s.getAllConfigItems(db)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, r)
@@ -62,14 +62,14 @@ type EditResponse struct {
 func (s *Service) editHandler(c *gin.Context) {
 	var req EditRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
 	db := utils.GetTiDBConnection(c)
 	warnings, err := s.editConfig(db, req.Kind, req.ID, req.NewValue)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 

--- a/pkg/apiserver/conprof/service.go
+++ b/pkg/apiserver/conprof/service.go
@@ -205,7 +205,7 @@ func (s *Service) GenConprofActionToken(c *gin.Context) {
 	q := c.Query("q")
 	token, err := utils.NewJWTString("conprof", q)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.String(http.StatusOK, token)
@@ -226,7 +226,7 @@ func (s *Service) parseJWTToken(c *gin.Context) {
 	token := c.Query("token")
 	queryStr, err := utils.ParseJWTString("conprof", token)
 	if err != nil {
-		_ = c.Error(rest.ErrBadRequest.WrapWithNoMessage(err))
+		rest.Error(c, rest.ErrBadRequest.WrapWithNoMessage(err))
 		return
 	}
 	c.Request.URL.RawQuery = queryStr

--- a/pkg/apiserver/debugapi/service.go
+++ b/pkg/apiserver/debugapi/service.go
@@ -91,19 +91,19 @@ func getExtFromContentTypeHeader(contentType string) string {
 func (s *Service) RequestEndpoint(c *gin.Context) {
 	var req endpoint.RequestPayload
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
 	resolved, err := s.resolver.ResolvePayload(req)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
 	writer, err := s.fSwap.NewFileWriter("debug_api")
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	defer func() {
@@ -112,7 +112,7 @@ func (s *Service) RequestEndpoint(c *gin.Context) {
 
 	resp, err := resolved.SendRequestAndPipe(s.httpClients, writer)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
@@ -121,7 +121,7 @@ func (s *Service) RequestEndpoint(c *gin.Context) {
 	downloadToken, err := writer.GetDownloadToken(fileName, time.Minute*5)
 	if err != nil {
 		// This shall never happen
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 

--- a/pkg/apiserver/diagnose/diagnose.go
+++ b/pkg/apiserver/diagnose/diagnose.go
@@ -131,7 +131,7 @@ type GenerateMetricsRelationRequest struct {
 func (s *Service) metricsRelationHandler(c *gin.Context) {
 	var req GenerateMetricsRelationRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
@@ -140,13 +140,13 @@ func (s *Service) metricsRelationHandler(c *gin.Context) {
 
 	path, err := s.generateMetricsRelation(startTime, endTime, req.Type)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
 	token, err := utils.NewJWTString("diagnose/metrics", path)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
@@ -164,13 +164,13 @@ func (s *Service) metricsRelationViewHandler(c *gin.Context) {
 	token := c.Query("token")
 	path, err := utils.ParseJWTString("diagnose/metrics", token)
 	if err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
 	data, err := ioutil.ReadFile(filepath.Clean(path))
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
@@ -196,7 +196,7 @@ type GenerateReportRequest struct {
 func (s *Service) reportsHandler(c *gin.Context) {
 	reports, err := GetReports(s.db)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, reports)
@@ -213,7 +213,7 @@ func (s *Service) reportsHandler(c *gin.Context) {
 func (s *Service) genReportHandler(c *gin.Context) {
 	var req GenerateReportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
@@ -229,7 +229,7 @@ func (s *Service) genReportHandler(c *gin.Context) {
 
 	reportID, err := NewReport(s.db, startTime, endTime, compareStartTime, compareEndTime)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
@@ -268,7 +268,7 @@ func (s *Service) reportStatusHandler(c *gin.Context) {
 	id := c.Param("id")
 	report, err := GetReport(s.db, id)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, &report)
@@ -299,7 +299,7 @@ func (s *Service) reportDataHandler(c *gin.Context) {
 	id := c.Param("id")
 	report, err := GetReport(s.db, id)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
@@ -324,7 +324,7 @@ type GenDiagnosisReportRequest struct {
 func (s *Service) genDiagnosisHandler(c *gin.Context) {
 	var req GenDiagnosisReportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.WrapWithNoMessage(err))
+		rest.Error(c, rest.ErrBadRequest.WrapWithNoMessage(err))
 		return
 	}
 

--- a/pkg/apiserver/info/info.go
+++ b/pkg/apiserver/info/info.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb-dashboard/pkg/utils/topology"
 	"github.com/pingcap/tidb-dashboard/pkg/utils/version"
 	"github.com/pingcap/tidb-dashboard/util/featureflag"
+	"github.com/pingcap/tidb-dashboard/util/rest"
 )
 
 type ServiceParams struct {
@@ -82,12 +83,12 @@ func (s *Service) infoHandler(c *gin.Context) {
 	versionWithoutSuffix := strings.Split(s.params.Config.FeatureVersion, "-")[0]
 	v, err := semver.NewVersion(versionWithoutSuffix)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	constraint, err := semver.NewConstraint(">= v5.4.0")
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
@@ -146,7 +147,7 @@ func (s *Service) databasesHandler(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	err := db.Raw("SHOW DATABASES").Scan(&result).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	strs := []string{}
@@ -181,7 +182,7 @@ func (s *Service) tablesHandler(c *gin.Context) {
 
 	err := tx.Order("TABLE_NAME").Scan(&result).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 

--- a/pkg/apiserver/logsearch/pack.go
+++ b/pkg/apiserver/logsearch/pack.go
@@ -19,7 +19,7 @@ func serveTaskForDownload(task *TaskModel, c *gin.Context) {
 		logPath = task.SlowLogStorePath
 	}
 	if logPath == nil {
-		_ = c.Error(rest.ErrBadRequest.New("Log is not ready"))
+		rest.Error(c, rest.ErrBadRequest.New("Log is not ready"))
 		return
 	}
 	c.FileAttachment(*logPath, fmt.Sprintf("logs-%s.zip", task.Target.FileName()))
@@ -33,7 +33,7 @@ func serveMultipleTaskForDownload(tasks []*TaskModel, c *gin.Context) {
 			logPath = task.SlowLogStorePath
 		}
 		if logPath == nil {
-			_ = c.Error(rest.ErrBadRequest.New("Some logs are not available"))
+			rest.Error(c, rest.ErrBadRequest.New("Some logs are not available"))
 			return
 		}
 		filePaths = append(filePaths, *logPath)

--- a/pkg/apiserver/logsearch/service.go
+++ b/pkg/apiserver/logsearch/service.go
@@ -105,11 +105,11 @@ type TaskGroupResponse struct {
 func (s *Service) CreateTaskGroup(c *gin.Context) {
 	var req CreateTaskGroupRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	if len(req.Targets) == 0 {
-		_ = c.Error(rest.ErrBadRequest.New("Expect at least 1 target"))
+		rest.Error(c, rest.ErrBadRequest.New("Expect at least 1 target"))
 		return
 	}
 	stats := model.NewRequestTargetStatisticsFromArray(&req.Targets)
@@ -119,7 +119,7 @@ func (s *Service) CreateTaskGroup(c *gin.Context) {
 		TargetStats:   stats,
 	}
 	if err := s.db.Create(&taskGroup).Error; err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	tasks := make([]*TaskModel, 0, len(req.Targets))
@@ -154,7 +154,7 @@ func (s *Service) GetAllTaskGroups(c *gin.Context) {
 	var taskGroups []*TaskGroupModel
 	err := s.db.Find(&taskGroups).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
@@ -174,12 +174,12 @@ func (s *Service) GetTaskGroup(c *gin.Context) {
 	var tasks []*TaskModel
 	err := s.db.First(&taskGroup, "id = ?", taskGroupID).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	err = s.db.Where("task_group_id = ?", taskGroupID).Find(&tasks).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	resp := TaskGroupResponse{
@@ -205,7 +205,7 @@ func (s *Service) GetTaskGroupPreview(c *gin.Context) {
 		Limit(TaskMaxPreviewLines).
 		Find(&lines).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, lines)
@@ -222,20 +222,20 @@ func (s *Service) GetTaskGroupPreview(c *gin.Context) {
 func (s *Service) RetryTask(c *gin.Context) {
 	taskGroupID, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
 	// Currently we can only retry finished task group.
 	taskGroup := TaskGroupModel{}
 	if err := s.db.Where("id = ? AND state = ?", taskGroupID, TaskGroupStateFinished).First(&taskGroup).Error; err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
 	tasks := make([]*TaskModel, 0)
 	if err := s.db.Where("task_group_id = ? AND state = ?", taskGroupID, TaskStateError).Find(&tasks).Error; err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
@@ -270,17 +270,17 @@ func (s *Service) RetryTask(c *gin.Context) {
 func (s *Service) CancelTask(c *gin.Context) {
 	taskGroupID, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	taskGroup := TaskGroupModel{}
 	err = s.db.First(&taskGroup, taskGroupID).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	if taskGroup.State != TaskGroupStateRunning {
-		_ = c.Error(rest.ErrBadRequest.New("Task is not running"))
+		rest.Error(c, rest.ErrBadRequest.New("Task is not running"))
 		return
 	}
 	s.scheduler.AsyncAbort(uint(taskGroupID))
@@ -299,7 +299,7 @@ func (s *Service) DeleteTaskGroup(c *gin.Context) {
 	taskGroup := TaskGroupModel{}
 	err := s.db.Where("id = ? AND state != ?", taskGroupID, TaskGroupStateRunning).First(&taskGroup).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	taskGroup.Delete(s.db)
@@ -319,7 +319,7 @@ func (s *Service) GetDownloadToken(c *gin.Context) {
 	str := strings.Join(ids, ",")
 	token, err := utils.NewJWTString("logs/download", str)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.String(http.StatusOK, token)
@@ -336,7 +336,7 @@ func (s *Service) DownloadLogs(c *gin.Context) {
 	token := c.Query("token")
 	str, err := utils.ParseJWTString("logs/download", token)
 	if err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	ids := strings.Split(str, ",")
@@ -354,7 +354,7 @@ func (s *Service) DownloadLogs(c *gin.Context) {
 
 	switch len(tasks) {
 	case 0:
-		_ = c.Error(rest.ErrBadRequest.New("Expect at least 1 target"))
+		rest.Error(c, rest.ErrBadRequest.New("Expect at least 1 target"))
 	case 1:
 		serveTaskForDownload(tasks[0], c)
 	default:

--- a/pkg/apiserver/metrics/router.go
+++ b/pkg/apiserver/metrics/router.go
@@ -45,17 +45,17 @@ func RegisterRouter(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 func (s *Service) queryMetrics(c *gin.Context) {
 	var req QueryRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
 	addr, err := s.getPromAddressFromCache()
 	if err != nil {
-		_ = c.Error(ErrLoadPrometheusAddressFailed.Wrap(err, "Load prometheus address failed"))
+		rest.Error(c, ErrLoadPrometheusAddressFailed.Wrap(err, "Load prometheus address failed"))
 		return
 	}
 	if addr == "" {
-		_ = c.Error(ErrPrometheusNotFound.New("Prometheus is not deployed in the cluster"))
+		rest.Error(c, ErrPrometheusNotFound.New("Prometheus is not deployed in the cluster"))
 		return
 	}
 
@@ -68,25 +68,25 @@ func (s *Service) queryMetrics(c *gin.Context) {
 	uri := fmt.Sprintf("%s/api/v1/query_range?%s", addr, params.Encode())
 	promReq, err := http.NewRequestWithContext(s.lifecycleCtx, http.MethodGet, uri, nil)
 	if err != nil {
-		_ = c.Error(ErrPrometheusQueryFailed.Wrap(err, "failed to build Prometheus request"))
+		rest.Error(c, ErrPrometheusQueryFailed.Wrap(err, "failed to build Prometheus request"))
 		return
 	}
 
 	promResp, err := s.params.HTTPClient.WithTimeout(defaultPromQueryTimeout).Do(promReq)
 	if err != nil {
-		_ = c.Error(ErrPrometheusQueryFailed.Wrap(err, "failed to send requests to Prometheus"))
+		rest.Error(c, ErrPrometheusQueryFailed.Wrap(err, "failed to send requests to Prometheus"))
 		return
 	}
 
 	defer promResp.Body.Close()
 	if promResp.StatusCode != http.StatusOK {
-		_ = c.Error(ErrPrometheusQueryFailed.New("failed to query Prometheus"))
+		rest.Error(c, ErrPrometheusQueryFailed.New("failed to query Prometheus"))
 		return
 	}
 
 	body, err := ioutil.ReadAll(promResp.Body)
 	if err != nil {
-		_ = c.Error(ErrPrometheusQueryFailed.Wrap(err, "failed to read Prometheus query result"))
+		rest.Error(c, ErrPrometheusQueryFailed.Wrap(err, "failed to read Prometheus query result"))
 		return
 	}
 
@@ -107,12 +107,12 @@ type GetPromAddressConfigResponse struct {
 func (s *Service) getPromAddressConfig(c *gin.Context) {
 	cAddr, err := s.resolveCustomizedPromAddress(true)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	dAddr, err := s.resolveDeployedPromAddress()
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, GetPromAddressConfigResponse{
@@ -139,12 +139,12 @@ type PutCustomPromAddressResponse struct {
 func (s *Service) putCustomPromAddress(c *gin.Context) {
 	var req PutCustomPromAddressRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	addr, err := s.setCustomPromAddress(req.Addr)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, PutCustomPromAddressResponse{

--- a/pkg/apiserver/queryeditor/service.go
+++ b/pkg/apiserver/queryeditor/service.go
@@ -123,7 +123,7 @@ func executeStatements(context context.Context, db *sql.DB, statements string) (
 func (s *Service) runHandler(c *gin.Context) {
 	var req RunRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 

--- a/pkg/apiserver/slowquery/service.go
+++ b/pkg/apiserver/slowquery/service.go
@@ -66,14 +66,14 @@ func registerRouter(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 func (s *Service) getList(c *gin.Context) {
 	var req GetListRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
 	db := utils.GetTiDBConnection(c)
 	results, err := QuerySlowLogList(&req, s.params.SysSchema, db.Table(SlowQueryTable))
 	if err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
@@ -89,14 +89,14 @@ func (s *Service) getList(c *gin.Context) {
 func (s *Service) getDetails(c *gin.Context) {
 	var req GetDetailRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
 	db := utils.GetTiDBConnection(c)
 	result, err := QuerySlowLogDetail(&req, db.Table(SlowQueryTable))
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, *result)
@@ -113,7 +113,7 @@ func (s *Service) getDetails(c *gin.Context) {
 func (s *Service) downloadTokenHandler(c *gin.Context) {
 	var req GetListRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	fields := []string{}
@@ -123,11 +123,11 @@ func (s *Service) downloadTokenHandler(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	list, err := QuerySlowLogList(&req, s.params.SysSchema, db.Table(SlowQueryTable))
 	if err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	if len(list) == 0 {
-		_ = c.Error(ErrNoData.NewWithNoMessage())
+		rest.Error(c, ErrNoData.NewWithNoMessage())
 		return
 	}
 
@@ -148,7 +148,7 @@ func (s *Service) downloadTokenHandler(c *gin.Context) {
 		fmt.Sprintf("slowquery_%s_%s_*.csv", beginTime, endTime),
 		"slowquery/download")
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.String(http.StatusOK, token)
@@ -176,7 +176,7 @@ func (s *Service) queryTableColumns(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	cs, err := QueryTableColumns(s.params.SysSchema, db)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, cs)

--- a/pkg/apiserver/statement/service.go
+++ b/pkg/apiserver/statement/service.go
@@ -80,7 +80,7 @@ func (s *Service) configHandler(c *gin.Context) {
 	cfg := &EditableConfig{}
 	err := db.Raw(buildGlobalConfigProjectionSelectSQL(cfg)).Find(cfg).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, cfg)
@@ -95,7 +95,7 @@ func (s *Service) configHandler(c *gin.Context) {
 func (s *Service) modifyConfigHandler(c *gin.Context) {
 	var config EditableConfig
 	if err := c.ShouldBindJSON(&config); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	db := utils.GetTiDBConnection(c)
@@ -108,7 +108,7 @@ func (s *Service) modifyConfigHandler(c *gin.Context) {
 	}
 	err := db.Exec(sqlWithNamedArgument, &config).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 
@@ -124,7 +124,7 @@ func (s *Service) timeRangesHandler(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	timeRanges, err := queryTimeRanges(db)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, timeRanges)
@@ -139,7 +139,7 @@ func (s *Service) stmtTypesHandler(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	stmtTypes, err := queryStmtTypes(db)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, stmtTypes)
@@ -164,7 +164,7 @@ type GetStatementsRequest struct {
 func (s *Service) listHandler(c *gin.Context) {
 	var req GetStatementsRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	db := utils.GetTiDBConnection(c)
@@ -180,7 +180,7 @@ func (s *Service) listHandler(c *gin.Context) {
 		req.Text,
 		fields)
 	if err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	c.JSON(http.StatusOK, overviews)
@@ -202,13 +202,13 @@ type GetPlansRequest struct {
 func (s *Service) plansHandler(c *gin.Context) {
 	var req GetPlansRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	db := utils.GetTiDBConnection(c)
 	plans, err := s.queryPlans(db, req.BeginTime, req.EndTime, req.SchemaName, req.Digest)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, plans)
@@ -228,13 +228,13 @@ type GetPlanDetailRequest struct {
 func (s *Service) planDetailHandler(c *gin.Context) {
 	var req GetPlanDetailRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	db := utils.GetTiDBConnection(c)
 	result, err := s.queryPlanDetail(db, req.BeginTime, req.EndTime, req.SchemaName, req.Digest, req.Plans)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, result)
@@ -251,7 +251,7 @@ func (s *Service) planDetailHandler(c *gin.Context) {
 func (s *Service) downloadTokenHandler(c *gin.Context) {
 	var req GetStatementsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	db := utils.GetTiDBConnection(c)
@@ -267,11 +267,11 @@ func (s *Service) downloadTokenHandler(c *gin.Context) {
 		req.Text,
 		fields)
 	if err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	if len(overviews) == 0 {
-		_ = c.Error(ErrNoData.NewWithNoMessage())
+		rest.Error(c, ErrNoData.NewWithNoMessage())
 		return
 	}
 
@@ -292,7 +292,7 @@ func (s *Service) downloadTokenHandler(c *gin.Context) {
 		fmt.Sprintf("statements_%s_%s_*.csv", beginTime, endTime),
 		"statements/download")
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.String(http.StatusOK, token)
@@ -319,7 +319,7 @@ func (s *Service) queryTableColumns(c *gin.Context) {
 	db := utils.GetTiDBConnection(c)
 	cs, err := s.params.SysSchema.GetTableColumnNames(db, statementsTable)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, funk.UniqString(append(cs, getVirtualFields(cs)...)))

--- a/pkg/apiserver/topsql/service.go
+++ b/pkg/apiserver/topsql/service.go
@@ -136,7 +136,7 @@ func (s *Service) GetConfig(c *gin.Context) {
 	cfg := &EditableConfig{}
 	err := db.Raw("SELECT @@GLOBAL.tidb_enable_top_sql as tidb_enable_top_sql").Find(cfg).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, cfg)
@@ -152,14 +152,14 @@ func (s *Service) GetConfig(c *gin.Context) {
 func (s *Service) UpdateConfig(c *gin.Context) {
 	var cfg EditableConfig
 	if err := c.ShouldBindJSON(&cfg); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
 	db := utils.GetTiDBConnection(c)
 	err := db.Exec("SET @@GLOBAL.tidb_enable_top_sql = @Enable", &cfg).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 

--- a/pkg/apiserver/user/auth.go
+++ b/pkg/apiserver/user/auth.go
@@ -187,7 +187,7 @@ func NewAuthService(featureFlags *featureflag.Registry) *AuthService {
 				// The remaining error comes from checking tokens for protected endpoints.
 				err = rest.ErrUnauthenticated.NewWithNoMessage()
 			}
-			_ = c.Error(err)
+			rest.Error(c, err)
 			return err.Error()
 		},
 		Unauthorized: func(c *gin.Context, code int, message string) {
@@ -242,12 +242,12 @@ func (s *AuthService) MWRequireSharePriv() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		u := utils.GetSession(c)
 		if u == nil {
-			_ = c.Error(rest.ErrUnauthenticated.NewWithNoMessage())
+			rest.Error(c, rest.ErrUnauthenticated.NewWithNoMessage())
 			c.Abort()
 			return
 		}
 		if !u.IsShareable {
-			_ = c.Error(rest.ErrForbidden.NewWithNoMessage())
+			rest.Error(c, rest.ErrForbidden.NewWithNoMessage())
 			c.Abort()
 			return
 		}
@@ -259,12 +259,12 @@ func (s *AuthService) MWRequireWritePriv() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		u := utils.GetSession(c)
 		if u == nil {
-			_ = c.Error(rest.ErrUnauthenticated.NewWithNoMessage())
+			rest.Error(c, rest.ErrUnauthenticated.NewWithNoMessage())
 			c.Abort()
 			return
 		}
 		if !u.IsWriteable {
-			_ = c.Error(rest.ErrForbidden.NewWithNoMessage())
+			rest.Error(c, rest.ErrForbidden.NewWithNoMessage())
 			c.Abort()
 			return
 		}
@@ -290,7 +290,7 @@ func (s *AuthService) GetLoginInfoHandler(c *gin.Context) {
 	for typeID, a := range s.authenticators {
 		enabled, err := a.IsEnabled()
 		if err != nil {
-			_ = c.Error(err)
+			rest.Error(c, err)
 			return
 		}
 		if enabled {
@@ -329,19 +329,19 @@ type GetSignOutInfoRequest struct {
 func (s *AuthService) getSignOutInfoHandler(c *gin.Context) {
 	var req GetSignOutInfoRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
 	u := utils.GetSession(c)
 	a, ok := s.authenticators[u.AuthFrom]
 	if !ok {
-		_ = c.Error(ErrUnsupportedAuthType.NewWithNoMessage())
+		rest.Error(c, ErrUnsupportedAuthType.NewWithNoMessage())
 		return
 	}
 	si, err := a.SignOutInfo(u, req.RedirectURL)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, si)

--- a/pkg/apiserver/user/code/router.go
+++ b/pkg/apiserver/user/code/router.go
@@ -37,21 +37,21 @@ type ShareResponse struct {
 func (s *Service) ShareHandler(c *gin.Context) {
 	var req ShareRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
 	expiry := time.Second * time.Duration(req.ExpireInSeconds)
 
 	if expiry > MaxSessionShareExpiry || expiry < 0 {
-		_ = c.Error(rest.ErrBadRequest.New("Invalid share expiry"))
+		rest.Error(c, rest.ErrBadRequest.New("Invalid share expiry"))
 		return
 	}
 
 	sessionUser := utils.GetSession(c)
 	code := s.SharingCodeFromSession(sessionUser, expiry, req.RevokeWritePriv)
 	if code == nil {
-		_ = c.Error(ErrShareFailed.New("Share session failed"))
+		rest.Error(c, ErrShareFailed.New("Share session failed"))
 		return
 	}
 

--- a/pkg/apiserver/user/sso/router.go
+++ b/pkg/apiserver/user/sso/router.go
@@ -38,12 +38,12 @@ type GetAuthURLRequest struct {
 func (s *Service) getAuthURLHandler(c *gin.Context) {
 	var req GetAuthURLRequest
 	if err := c.ShouldBindQuery(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	authURL, err := s.buildOAuthURL(req.RedirectURL, req.State, req.CodeVerifier)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.String(http.StatusOK, authURL)
@@ -59,7 +59,7 @@ func (s *Service) listImpersonationHandler(c *gin.Context) {
 	var resp []SSOImpersonationModel
 	err := s.params.LocalStore.Find(&resp).Error
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, resp)
@@ -82,13 +82,13 @@ type CreateImpersonationRequest struct {
 func (s *Service) createImpersonationHandler(c *gin.Context) {
 	var req CreateImpersonationRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
 	rec, err := s.createImpersonation(req.SQLUser, req.Password)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		if errorx.IsOfType(err, ErrUnsupportedUser) || errorx.IsOfType(err, ErrInvalidImpersonateCredential) {
 			c.Status(http.StatusBadRequest)
 		}
@@ -108,7 +108,7 @@ func (s *Service) createImpersonationHandler(c *gin.Context) {
 func (s *Service) getConfig(c *gin.Context) {
 	dc, err := s.params.ConfigManager.Get()
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, dc.SSO.CoreConfig)
@@ -130,7 +130,7 @@ type SetConfigRequest struct {
 func (s *Service) setConfig(c *gin.Context) {
 	var req SetConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 
@@ -138,7 +138,7 @@ func (s *Service) setConfig(c *gin.Context) {
 	if req.Config.Enabled {
 		wellKnownConfig, err := s.discoverOIDC(req.Config.DiscoveryURL)
 		if err != nil {
-			_ = c.Error(rest.ErrBadRequest.WrapWithNoMessage(err))
+			rest.Error(c, rest.ErrBadRequest.WrapWithNoMessage(err))
 			return
 		}
 		dConfig.AuthURL = wellKnownConfig.AuthURL
@@ -148,7 +148,7 @@ func (s *Service) setConfig(c *gin.Context) {
 	} else {
 		err := s.revokeAllImpersonations()
 		if err != nil {
-			_ = c.Error(err)
+			rest.Error(c, err)
 			return
 		}
 	}
@@ -157,7 +157,7 @@ func (s *Service) setConfig(c *gin.Context) {
 		dc.SSO = dConfig
 	}
 	if err := s.params.ConfigManager.Modify(opt); err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, req.Config)

--- a/pkg/apiserver/utils/export.go
+++ b/pkg/apiserver/utils/export.go
@@ -105,29 +105,29 @@ func ExportCSV(data [][]string, filename, tokenNamespace string) (token string, 
 func DownloadByToken(token, tokenNamespace string, c *gin.Context) {
 	tokenPlain, err := ParseJWTString(tokenNamespace, token)
 	if err != nil {
-		_ = c.Error(rest.ErrBadRequest.WrapWithNoMessage(err))
+		rest.Error(c, rest.ErrBadRequest.WrapWithNoMessage(err))
 		return
 	}
 	arr := strings.Fields(tokenPlain)
 	if len(arr) != 2 {
-		_ = c.Error(rest.ErrBadRequest.New("invalid token"))
+		rest.Error(c, rest.ErrBadRequest.New("invalid token"))
 		return
 	}
 	secretKey, err := base64.StdEncoding.DecodeString(arr[0])
 	if err != nil {
-		_ = c.Error(rest.ErrBadRequest.WrapWithNoMessage(err))
+		rest.Error(c, rest.ErrBadRequest.WrapWithNoMessage(err))
 		return
 	}
 
 	filePath := arr[1]
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	f, err := os.Open(filepath.Clean(filePath))
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 

--- a/pkg/apiserver/utils/mw_experimental.go
+++ b/pkg/apiserver/utils/mw_experimental.go
@@ -6,13 +6,15 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/pingcap/tidb-dashboard/util/rest"
 )
 
 func MWForbidByExperimentalFlag(enableExp bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if !enableExp {
 			c.Status(http.StatusForbidden)
-			_ = c.Error(ErrExpNotEnabled.NewWithNoMessage())
+			rest.Error(c, ErrExpNotEnabled.NewWithNoMessage())
 			c.Abort()
 			return
 		}

--- a/pkg/apiserver/utils/ngm.go
+++ b/pkg/apiserver/utils/ngm.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/pingcap/tidb-dashboard/pkg/utils/topology"
+	"github.com/pingcap/tidb-dashboard/util/rest"
 )
 
 var (
@@ -65,7 +66,7 @@ func (n *NgmProxy) Route(targetPath string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ngmAddr, err := n.getNgmAddrFromCache()
 		if err != nil {
-			_ = c.Error(err)
+			rest.Error(c, err)
 			return
 		}
 

--- a/pkg/apiserver/utils/tidb_conn.go
+++ b/pkg/apiserver/utils/tidb_conn.go
@@ -31,7 +31,7 @@ func MWConnectTiDB(tidbClient *tidb.Client) gin.HandlerFunc {
 		if !sessionUser.HasTiDBAuth {
 			// Only TiDBAuth is able to access. Raise error in this case.
 			// The error is privilege error instead of authorization error so that user will not be redirected.
-			_ = c.Error(rest.ErrForbidden.NewWithNoMessage())
+			rest.Error(c, rest.ErrForbidden.NewWithNoMessage())
 			c.Abort()
 			return
 		}
@@ -41,11 +41,11 @@ func MWConnectTiDB(tidbClient *tidb.Client) gin.HandlerFunc {
 			if errorx.IsOfType(err, tidb.ErrTiDBAuthFailed) {
 				// If TiDB conn is ok when login but fail this time, it means TiDB credential has been changed since
 				// login. In this case, we return unauthorized error, so that the front-end can let user to login again.
-				_ = c.Error(rest.ErrUnauthenticated.NewWithNoMessage())
+				rest.Error(c, rest.ErrUnauthenticated.NewWithNoMessage())
 			} else {
 				// For other kind of connection errors, for example, PD goes away, return these errors directly.
 				// In front-end we will simply display these errors but not ask user to login again.
-				_ = c.Error(err)
+				rest.Error(c, err)
 			}
 			c.Abort()
 			return

--- a/pkg/keyvisual/manager.go
+++ b/pkg/keyvisual/manager.go
@@ -95,7 +95,7 @@ func (s *Service) stopService() {
 func (s *Service) getDynamicConfig(c *gin.Context) {
 	dc, err := s.cfgManager.Get()
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, dc.KeyVisual)
@@ -112,14 +112,14 @@ func (s *Service) getDynamicConfig(c *gin.Context) {
 func (s *Service) setDynamicConfig(c *gin.Context) {
 	var req config.KeyVisualConfig
 	if err := c.ShouldBindJSON(&req); err != nil {
-		_ = c.Error(rest.ErrBadRequest.NewWithNoMessage())
+		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
 	var opt config.DynamicConfigOption = func(dc *config.DynamicConfig) {
 		dc.KeyVisual = req
 	}
 	if err := s.cfgManager.Modify(opt); err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, req)

--- a/scripts/go.sum
+++ b/scripts/go.sum
@@ -255,8 +255,9 @@ github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFF
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -325,8 +326,9 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=

--- a/util/featureflag/featureflag.go
+++ b/util/featureflag/featureflag.go
@@ -40,7 +40,7 @@ func (f *FeatureFlag) IsSupported() bool {
 func (f *FeatureFlag) VersionGuard() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if !f.isSupported {
-			_ = c.Error(ErrFeatureUnsupported.New(f.name).WithProperty(rest.HTTPCodeProperty(http.StatusForbidden)))
+			rest.Error(c, ErrFeatureUnsupported.New(f.name).WithProperty(rest.HTTPCodeProperty(http.StatusForbidden)))
 			c.Abort()
 			return
 		}

--- a/util/jsonserde/1_main_test.go
+++ b/util/jsonserde/1_main_test.go
@@ -1,0 +1,13 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+package jsonserde
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb-dashboard/util/testutil/testdefault"
+)
+
+func TestMain(m *testing.M) {
+	testdefault.TestMain(m)
+}

--- a/util/jsonserde/convert.go
+++ b/util/jsonserde/convert.go
@@ -1,0 +1,28 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+// Copyright (c) 2017 Eason Lin
+
+package jsonserde
+
+import (
+	"unicode"
+)
+
+func swagToSnakeCase(in string) string {
+	// Copied from https://github.com/swaggo/swag/blob/8ffc6c29c01a13fb01183ee91d0fcc5fc586b431/field_parser.go#L81
+	// so that the serialized value can be aligned with the swagger spec.
+
+	runes := []rune(in)
+	length := len(runes)
+
+	var out []rune
+	for i := 0; i < length; i++ {
+		if i > 0 && unicode.IsUpper(runes[i]) &&
+			((i+1 < length && unicode.IsLower(runes[i+1])) || unicode.IsLower(runes[i-1])) {
+			out = append(out, '_')
+		}
+		out = append(out, unicode.ToLower(runes[i]))
+	}
+
+	return string(out)
+}

--- a/util/jsonserde/default.go
+++ b/util/jsonserde/default.go
@@ -1,0 +1,22 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+// Package jsonserde sets default config for json-iterator.
+//
+// If this package is imported, json-iterator will:
+// - encode time as millisecond timestamps
+// - encode field names as lower_snake_case
+package jsonserde
+
+import (
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/json-iterator/go/extra"
+)
+
+func init() {
+	extra.RegisterTimeAsInt64Codec(time.Millisecond)
+	extra.SetNamingStrategy(swagToSnakeCase)
+}
+
+var Default = jsoniter.ConfigCompatibleWithStandardLibrary

--- a/util/jsonserde/default_test.go
+++ b/util/jsonserde/default_test.go
@@ -1,0 +1,33 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+package jsonserde
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testStruct struct {
+	FooBar  string
+	SQLTime time.Time
+}
+
+func TestMarshal(t *testing.T) {
+	data := testStruct{
+		FooBar:  "zoo",
+		SQLTime: time.Unix(0, 1641733771580123000),
+	}
+	val, err := Default.Marshal(data)
+	require.NoError(t, err)
+	require.Equal(t, `{"foo_bar":"zoo","sql_time":1641733771580}`, string(val))
+}
+
+func TestUnmarshal(t *testing.T) {
+	var data testStruct
+	err := Default.Unmarshal([]byte(`{"foo_bar":"zoo","sql_time":1641733771580}`), &data)
+	require.NoError(t, err)
+	require.Equal(t, "zoo", data.FooBar)
+	require.Equal(t, time.Unix(0, 1641733771580000000), data.SQLTime)
+}

--- a/util/jsonserde/ginadapter/1_main_test.go
+++ b/util/jsonserde/ginadapter/1_main_test.go
@@ -1,0 +1,13 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+package ginadapter
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb-dashboard/util/testutil/testdefault"
+)
+
+func TestMain(m *testing.M) {
+	testdefault.TestMain(m)
+}

--- a/util/jsonserde/ginadapter/binding.go
+++ b/util/jsonserde/ginadapter/binding.go
@@ -1,0 +1,50 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+// Copyright 2014 Manu Martinez-Almeida.
+
+package ginadapter
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin/binding"
+
+	"github.com/pingcap/tidb-dashboard/util/jsonserde"
+)
+
+var Binding = jsonBinding{}
+
+type jsonBinding struct{}
+
+func (jsonBinding) Name() string {
+	return "json"
+}
+
+func (jsonBinding) Bind(req *http.Request, obj interface{}) error {
+	if req == nil || req.Body == nil {
+		return fmt.Errorf("invalid request")
+	}
+	return decodeJSON(req.Body, obj)
+}
+
+func (jsonBinding) BindBody(body []byte, obj interface{}) error {
+	return decodeJSON(bytes.NewReader(body), obj)
+}
+
+func decodeJSON(r io.Reader, obj interface{}) error {
+	decoder := jsonserde.Default.NewDecoder(r)
+	if err := decoder.Decode(obj); err != nil {
+		return err
+	}
+	return validate(obj)
+}
+
+func validate(obj interface{}) error {
+	if binding.Validator == nil {
+		return nil
+	}
+	return binding.Validator.ValidateStruct(obj)
+}

--- a/util/jsonserde/ginadapter/binding_test.go
+++ b/util/jsonserde/ginadapter/binding_test.go
@@ -1,0 +1,46 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+package ginadapter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONBindingBindBody(t *testing.T) {
+	type sampleStruct struct {
+		ABCFoo string
+		Bar    string
+		Box    string `json:"_box"`
+	}
+	var s sampleStruct
+	err := jsonBinding{}.BindBody([]byte(`{"Abc_foo": "FOO", "Box": "zzz", "Bar": "xyz"}`), &s)
+	require.NoError(t, err)
+	require.Equal(t, "FOO", s.ABCFoo)
+	require.Equal(t, "xyz", s.Bar)
+	require.Equal(t, "", s.Box)
+
+	s = sampleStruct{}
+	err = jsonBinding{}.BindBody([]byte(`{"ABCFoo": "z", "_Box": "yo"}`), &s)
+	require.NoError(t, err)
+	require.Equal(t, "", s.ABCFoo)
+	require.Equal(t, "", s.Bar)
+	require.Equal(t, "yo", s.Box)
+
+	s = sampleStruct{}
+	err = jsonBinding{}.BindBody([]byte(`{"abc_foo": "x", "_box": "yoo", "bar": "jojo"}`), &s)
+	require.NoError(t, err)
+	require.Equal(t, "x", s.ABCFoo)
+	require.Equal(t, "jojo", s.Bar)
+	require.Equal(t, "yoo", s.Box)
+}
+
+func TestJSONBindingBindBodyMap(t *testing.T) {
+	s := make(map[string]string)
+	err := jsonBinding{}.BindBody([]byte(`{"foo": "FOO","Hello":"world"}`), &s)
+	require.NoError(t, err)
+	require.Len(t, s, 2)
+	require.Equal(t, "FOO", s["foo"])
+	require.Equal(t, "world", s["Hello"])
+}

--- a/util/jsonserde/ginadapter/render.go
+++ b/util/jsonserde/ginadapter/render.go
@@ -1,0 +1,38 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+// Copyright 2014 Manu Martinez-Almeida.
+
+package ginadapter
+
+import (
+	"net/http"
+
+	"github.com/pingcap/tidb-dashboard/util/jsonserde"
+)
+
+var jsonContentType = []string{"application/json; charset=utf-8"}
+
+func writeContentType(w http.ResponseWriter, value []string) {
+	header := w.Header()
+	if val := header["Content-Type"]; len(val) == 0 {
+		header["Content-Type"] = value
+	}
+}
+
+type Renderer struct {
+	Data interface{}
+}
+
+func (j Renderer) Render(w http.ResponseWriter) error {
+	writeContentType(w, jsonContentType)
+	jsonBytes, err := jsonserde.Default.Marshal(j.Data)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(jsonBytes)
+	return err
+}
+
+func (j Renderer) WriteContentType(w http.ResponseWriter) {
+	writeContentType(w, jsonContentType)
+}

--- a/util/jsonserde/ginadapter/render_test.go
+++ b/util/jsonserde/ginadapter/render_test.go
@@ -1,0 +1,36 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+package ginadapter
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderer(t *testing.T) {
+	w := httptest.NewRecorder()
+	type User struct {
+		FullName string
+		Age      int
+	}
+	data := User{
+		FullName: "zoo",
+		Age:      18,
+	}
+
+	err := (Renderer{data}).Render(w)
+
+	require.NoError(t, err)
+	require.Equal(t, `{"full_name":"zoo","age":18}`, w.Body.String())
+	require.Equal(t, `application/json; charset=utf-8`, w.Header().Get("Content-Type"))
+}
+
+func TestRendererError(t *testing.T) {
+	w := httptest.NewRecorder()
+	data := make(chan int)
+
+	err := (Renderer{data}).Render(w)
+	require.EqualError(t, err, "chan int is unsupported type")
+}

--- a/util/rest/context_helpers.go
+++ b/util/rest/context_helpers.go
@@ -1,0 +1,43 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+package rest
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/joomcode/errorx"
+
+	"github.com/pingcap/tidb-dashboard/util/jsonserde/ginadapter"
+)
+
+// Error appends an error to the context, which will later becomes an error message returned to the client.
+// You should not write any other body to the client before or after calling this function.
+// Otherwise there will be no error message written to the client.
+// See `ErrorHandlerFn` for more details.
+func Error(c *gin.Context, err error) {
+	_ = c.Error(errorx.EnsureStackTrace(err))
+}
+
+// JSON writes a JSON string to the client with the given status code.
+// The key of te `obj` will be serialized in snake_case by default (see `jsonserde` package).
+func JSON(c *gin.Context, code int, obj interface{}) {
+	c.Render(code, ginadapter.Renderer{Data: obj})
+}
+
+// OK writes a JSON string to the client with the status code 200.
+// The key of te `obj` will be serialized in snake_case by default (see `jsonserde` package).
+func OK(c *gin.Context, obj interface{}) {
+	JSON(c, http.StatusOK, obj)
+}
+
+// MustBind decodes the request body to the passed struct pointer.
+// If error occurs, `ErrBadRequest` will be recorded in the context and `false` will be returned. You should early
+// return the handler in this case.
+func MustBind(c *gin.Context, obj interface{}) bool {
+	if err := c.ShouldBindWith(obj, ginadapter.Binding); err != nil {
+		Error(c, ErrBadRequest.WrapWithNoMessage(err))
+		return false
+	}
+	return true
+}

--- a/util/rest/context_helpers_test.go
+++ b/util/rest/context_helpers_test.go
@@ -1,0 +1,66 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/tidb-dashboard/util/testutil/gintest"
+)
+
+func TestError(t *testing.T) {
+	c, r := gintest.CtxGet(nil)
+	Error(c, fmt.Errorf("my error"))
+	require.Len(t, c.Errors, 1)
+	require.EqualError(t, c.Errors[0].Err, "my error")
+	require.Empty(t, r.Body.String())
+}
+
+func TestJSON(t *testing.T) {
+	c, r := gintest.CtxGet(nil)
+	JSON(c, http.StatusBadRequest, "foo")
+	require.Empty(t, c.Errors)
+	require.Equal(t, http.StatusBadRequest, r.Code)
+	require.Equal(t, `"foo"`, r.Body.String())
+
+	type example struct {
+		FooBar string
+	}
+	c, r = gintest.CtxGet(nil)
+	JSON(c, http.StatusOK, example{FooBar: "value"})
+	require.Empty(t, c.Errors)
+	require.Equal(t, http.StatusOK, r.Code)
+	require.Equal(t, `{"foo_bar":"value"}`, r.Body.String())
+}
+
+func TestMustBind(t *testing.T) {
+	c, r := gintest.CtxPost(nil, `"abc"`)
+
+	var v string
+	bindResult := MustBind(c, &v)
+	require.True(t, bindResult)
+	require.Equal(t, "abc", v)
+	require.Empty(t, c.Errors)
+	require.Empty(t, r.Body.String())
+
+	c, r = gintest.CtxPost(nil, `123`)
+	bindResult = MustBind(c, &v)
+	require.False(t, bindResult)
+	require.Len(t, c.Errors, 1)
+	require.Error(t, c.Errors[0].Err)
+	require.True(t, errorx.IsOfType(c.Errors[0].Err, ErrBadRequest))
+	require.Empty(t, r.Body.String())
+}
+
+func TestOK(t *testing.T) {
+	c, r := gintest.CtxGet(nil)
+	OK(c, "xyz")
+	require.Empty(t, c.Errors)
+	require.Equal(t, http.StatusOK, r.Code)
+	require.Equal(t, `"xyz"`, r.Body.String())
+}

--- a/util/rest/error.go
+++ b/util/rest/error.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/joomcode/errorx"
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
 )
 
 var (
@@ -82,6 +84,12 @@ func ErrorHandlerFn() gin.HandlerFunc {
 			statusCode = extractHTTPCodeFromError(err.Err)
 		}
 
-		c.AbortWithStatusJSON(statusCode, NewErrorResponse(err.Err))
+		errResponse := NewErrorResponse(err.Err)
+
+		log.Warn("Error when handling request",
+			zap.String("uri", c.Request.RequestURI),
+			zap.String("remoteAddr", c.Request.RemoteAddr),
+			zap.String("errorFullText", errResponse.FullText))
+		c.AbortWithStatusJSON(statusCode, errResponse)
 	}
 }

--- a/util/rest/error.go
+++ b/util/rest/error.go
@@ -61,7 +61,7 @@ func extractHTTPCodeFromError(err error) int {
 }
 
 // ErrorHandlerFn creates a handler func that turns (last) error in the context into an APIError json response.
-// In handlers, `c.Error(err)` can be used to attach the error to the context.
+// In handlers, `rest.Error(c, err)` can be used to attach the error to the context.
 // When error is attached in the context:
 // - The handler can optionally assign the HTTP status code.
 // - The handler must not self-generate a response body.

--- a/util/rest/error_resp.go
+++ b/util/rest/error_resp.go
@@ -69,8 +69,8 @@ func buildCode(err error) string {
 			break
 		}
 		if causeEx.Type().RootNamespace().FullName() == "synthetic" {
-			// Ignore standard transparent types..
-			// User-defined transparent types are not detectable however.
+			// Ignore standard transparent types.
+			// User-defined transparent types are not detectable, however.
 			cause = causeEx.Cause()
 		} else {
 			return causeEx.Type().FullName()
@@ -86,11 +86,18 @@ func removeErrorPrefix(code string) string {
 	return strings.TrimPrefix(code, "error.")
 }
 
+func buildDetailMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf("%+v", errorx.EnsureStackTrace(err))
+}
+
 func NewErrorResponse(err error) ErrorResponse {
 	return ErrorResponse{
 		Error:    true,
 		Message:  buildSimpleMessage(err),
 		Code:     removeErrorPrefix(buildCode(err)),
-		FullText: fmt.Sprintf("%+v", err),
+		FullText: buildDetailMessage(err),
 	}
 }

--- a/util/rest/error_resp_test.go
+++ b/util/rest/error_resp_test.go
@@ -5,103 +5,162 @@ package rest
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/joomcode/errorx"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildSimpleMessage(t *testing.T) {
+func TestErrors(t *testing.T) {
 	ns := errorx.NewNamespace("ns")
 	errTypeInner := ns.NewType("errInner")
 	errTypeOuter := ns.NewType("errOuter")
+
+	tests := []struct {
+		err                 error
+		expectCode          string
+		expectSimpleMessage string
+		expectDetailMessage string
+	}{
+		{
+			fmt.Errorf(""),
+			"common.internal",
+			"",
+			"",
+		},
+		{
+			fmt.Errorf("foo"),
+			"common.internal",
+			"foo",
+			"foo",
+		},
+		{
+			os.ErrNotExist,
+			"common.internal",
+			"file does not exist",
+			"file does not exist",
+		},
+		{
+			fmt.Errorf("internal error: %w", os.ErrNotExist),
+			"common.internal",
+			"internal error: file does not exist",
+			"internal error: file does not exist",
+		},
+		{
+			errTypeInner.NewWithNoMessage(),
+			"ns.errInner",
+			"ns.errInner",
+			"ns.errInner",
+		},
+		{
+			errTypeInner.New("foo"),
+			"ns.errInner",
+			"foo",
+			"ns.errInner: foo",
+		},
+		{
+			errTypeOuter.WrapWithNoMessage(os.ErrNotExist),
+			"ns.errOuter",
+			"file does not exist",
+			"ns.errOuter: file does not exist",
+		},
+		{
+			errTypeOuter.Wrap(os.ErrNotExist, "internal error"),
+			"ns.errOuter",
+			"internal error, caused by: file does not exist",
+			"ns.errOuter: internal error, cause: file does not exist",
+		},
+		{
+			errTypeOuter.WrapWithNoMessage(errTypeInner.NewWithNoMessage()),
+			"ns.errOuter",
+			"ns.errOuter: ns.errInner",
+			"ns.errOuter: ns.errInner",
+		},
+		{
+			errTypeOuter.WrapWithNoMessage(errTypeInner.New("foo")),
+			"ns.errOuter",
+			"foo",
+			"ns.errOuter: ns.errInner: foo",
+		},
+		{
+			errTypeOuter.WrapWithNoMessage(errTypeInner.WrapWithNoMessage(os.ErrNotExist)),
+			"ns.errOuter",
+			"file does not exist",
+			"ns.errOuter: ns.errInner: file does not exist",
+		},
+		{
+			errTypeOuter.WrapWithNoMessage(errTypeInner.WrapWithNoMessage(fmt.Errorf(""))),
+			"ns.errOuter",
+			"ns.errOuter: ns.errInner",
+			"ns.errOuter: ns.errInner",
+		},
+		{
+			errTypeOuter.WrapWithNoMessage(errTypeInner.Wrap(os.ErrNotExist, "internal error")),
+			"ns.errOuter",
+			"internal error, caused by: file does not exist",
+			"ns.errOuter: ns.errInner: internal error, cause: file does not exist",
+		},
+		{
+			errTypeOuter.Wrap(errTypeInner.NewWithNoMessage(), "gateway error"),
+			"ns.errOuter",
+			"gateway error",
+			"ns.errOuter: gateway error, cause: ns.errInner",
+		},
+		{
+			errTypeOuter.Wrap(errTypeInner.New("foo"), "gateway error"),
+			"ns.errOuter",
+			"gateway error, caused by: foo",
+			"ns.errOuter: gateway error, cause: ns.errInner: foo",
+		},
+		{
+			errTypeOuter.Wrap(errTypeInner.WrapWithNoMessage(os.ErrNotExist), "gateway error"),
+			"ns.errOuter",
+			"gateway error, caused by: file does not exist",
+			"ns.errOuter: gateway error, cause: ns.errInner: file does not exist",
+		},
+		{
+			errTypeOuter.Wrap(errTypeInner.Wrap(os.ErrNotExist, "internal error"), "gateway error"),
+			"ns.errOuter",
+			"gateway error, caused by: internal error, caused by: file does not exist",
+			"ns.errOuter: gateway error, cause: ns.errInner: internal error, cause: file does not exist",
+		},
+		{
+			errorx.Decorate(errorx.IllegalState.New("unfortunate"), "this could be so much better"),
+			"common.illegal_state",
+			"this could be so much better, caused by: unfortunate",
+			"this could be so much better, cause: common.illegal_state: unfortunate",
+		},
+		{
+			errorx.Decorate(os.ErrNotExist, "this could be so much better"),
+			"common.internal",
+			"this could be so much better, caused by: file does not exist",
+			"this could be so much better, cause: file does not exist",
+		},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("Case #%d", idx), func(t *testing.T) {
+			require.Equal(t, tt.expectSimpleMessage, buildSimpleMessage(tt.err))
+			require.Equal(t, tt.expectCode, buildCode(tt.err))
+			requireErrorAndStack(t, buildDetailMessage(tt.err), tt.expectDetailMessage)
+		})
+	}
 
 	require.Equal(t, "", buildSimpleMessage(nil))
-
-	err := fmt.Errorf("")
-	require.Equal(t, "", buildSimpleMessage(err))
-
-	err = fmt.Errorf("foo")
-	require.Equal(t, "foo", buildSimpleMessage(err))
-
-	err = os.ErrNotExist
-	require.Equal(t, "file does not exist", buildSimpleMessage(err))
-
-	err = fmt.Errorf("internal error: %w", os.ErrNotExist)
-	require.Equal(t, "internal error: file does not exist", buildSimpleMessage(err))
-
-	err = errTypeInner.NewWithNoMessage()
-	require.Equal(t, "ns.errInner", buildSimpleMessage(err))
-
-	err = errTypeInner.New("foo")
-	require.Equal(t, "foo", buildSimpleMessage(err))
-
-	err = errTypeOuter.WrapWithNoMessage(os.ErrNotExist)
-	require.Equal(t, "file does not exist", buildSimpleMessage(err))
-
-	err = errTypeOuter.Wrap(os.ErrNotExist, "internal error")
-	require.Equal(t, "internal error, caused by: file does not exist", buildSimpleMessage(err))
-
-	err = errTypeOuter.WrapWithNoMessage(errTypeInner.NewWithNoMessage())
-	require.Equal(t, "ns.errOuter: ns.errInner", buildSimpleMessage(err))
-
-	err = errTypeOuter.WrapWithNoMessage(errTypeInner.New("foo"))
-	require.Equal(t, "foo", buildSimpleMessage(err))
-
-	err = errTypeOuter.WrapWithNoMessage(errTypeInner.WrapWithNoMessage(os.ErrNotExist))
-	require.Equal(t, "file does not exist", buildSimpleMessage(err))
-
-	err = errTypeOuter.WrapWithNoMessage(errTypeInner.WrapWithNoMessage(fmt.Errorf("")))
-	require.Equal(t, "ns.errOuter: ns.errInner", buildSimpleMessage(err))
-
-	err = errTypeOuter.WrapWithNoMessage(errTypeInner.Wrap(os.ErrNotExist, "internal error"))
-	require.Equal(t, "internal error, caused by: file does not exist", buildSimpleMessage(err))
-
-	err = errTypeOuter.Wrap(errTypeInner.NewWithNoMessage(), "gateway error")
-	require.Equal(t, "gateway error", buildSimpleMessage(err))
-
-	err = errTypeOuter.Wrap(errTypeInner.New("foo"), "gateway error")
-	require.Equal(t, "gateway error, caused by: foo", buildSimpleMessage(err))
-
-	err = errTypeOuter.Wrap(errTypeInner.WrapWithNoMessage(os.ErrNotExist), "gateway error")
-	require.Equal(t, "gateway error, caused by: file does not exist", buildSimpleMessage(err))
-
-	err = errTypeOuter.Wrap(errTypeInner.Wrap(os.ErrNotExist, "internal error"), "gateway error")
-	require.Equal(t, "gateway error, caused by: internal error, caused by: file does not exist", buildSimpleMessage(err))
-
-	err = errorx.Decorate(errorx.IllegalState.New("unfortunate"), "this could be so much better")
-	require.Equal(t, "this could be so much better, caused by: unfortunate", buildSimpleMessage(err))
-
-	err = errorx.Decorate(os.ErrNotExist, "this could be so much better")
-	require.Equal(t, "this could be so much better, caused by: file does not exist", buildSimpleMessage(err))
+	require.Equal(t, "", buildCode(nil))
+	require.Equal(t, "", buildDetailMessage(nil))
 }
 
-func TestBuildCode(t *testing.T) {
-	ns := errorx.NewNamespace("ns")
-	errTypeInner := ns.NewType("errInner")
-	errTypeOuter := ns.NewType("errOuter")
+func requireErrorAndStack(t *testing.T, src string, errMessage string) {
+	lines := strings.SplitN(src, "\n", 2)
+	require.Equal(t, 2, len(lines))
+	require.Equal(t, errMessage, lines[0])
+	require.NotEmpty(t, lines[1])
 
-	err := fmt.Errorf("foo")
-	require.Equal(t, "common.internal", buildCode(err))
-
-	err = os.ErrNotExist
-	require.Equal(t, "common.internal", buildCode(err))
-
-	err = errTypeInner.NewWithNoMessage()
-	require.Equal(t, "ns.errInner", buildCode(err))
-
-	err = errTypeInner.New("foo")
-	require.Equal(t, "ns.errInner", buildCode(err))
-
-	err = errTypeInner.WrapWithNoMessage(os.ErrNotExist)
-	require.Equal(t, "ns.errInner", buildCode(err))
-
-	err = errTypeInner.Wrap(os.ErrNotExist, "foo")
-	require.Equal(t, "ns.errInner", buildCode(err))
-
-	err = errorx.Decorate(os.ErrNotExist, "this could be so much better")
-	require.Equal(t, "common.internal", buildCode(err))
-
-	err = errTypeOuter.Wrap(errTypeInner.NewWithNoMessage(), "foo")
-	require.Equal(t, "ns.errOuter", buildCode(err))
+	stacks := strings.Split(lines[1], "\n")
+	require.GreaterOrEqual(t, len(stacks), 2)
+	require.True(t, regexp.MustCompile(`^\s*at github\.com/.*?\(\)`).MatchString(stacks[0]))
+	require.True(t, regexp.MustCompile(`\.go:\d+$`).MatchString(stacks[1]))
 }

--- a/util/rest/error_test.go
+++ b/util/rest/error_test.go
@@ -48,7 +48,7 @@ func (suite *ErrorHandlerFnTestSuite) TestNoError() {
 	engine := gin.New()
 	engine.Use(ErrorHandlerFn())
 	engine.GET("/test", func(c *gin.Context) {
-		c.JSON(200, gin.H{
+		OK(c, gin.H{
 			"foo": "bar",
 		})
 	})
@@ -69,7 +69,7 @@ func (suite *ErrorHandlerFnTestSuite) TestNormalError() {
 	engine := gin.New()
 	engine.Use(ErrorHandlerFn())
 	engine.GET("/test", func(c *gin.Context) {
-		_ = c.Error(fmt.Errorf("some error"))
+		Error(c, fmt.Errorf("some error"))
 	})
 
 	r := httptest.NewRecorder()
@@ -83,7 +83,7 @@ func (suite *ErrorHandlerFnTestSuite) TestBuiltinError() {
 	engine := gin.New()
 	engine.Use(ErrorHandlerFn())
 	engine.GET("/test", func(c *gin.Context) {
-		_ = c.Error(ErrBadRequest.NewWithNoMessage())
+		Error(c, ErrBadRequest.NewWithNoMessage())
 	})
 
 	r := httptest.NewRecorder()
@@ -97,7 +97,7 @@ func (suite *ErrorHandlerFnTestSuite) TestOverrideStatusCode() {
 	engine := gin.New()
 	engine.Use(ErrorHandlerFn())
 	engine.GET("/test", func(c *gin.Context) {
-		_ = c.Error(ErrBadRequest.NewWithNoMessage())
+		Error(c, ErrBadRequest.NewWithNoMessage())
 		c.Status(http.StatusBadGateway)
 	})
 
@@ -112,18 +112,16 @@ func (suite *ErrorHandlerFnTestSuite) TestResponseAfterError() {
 	engine := gin.New()
 	engine.Use(ErrorHandlerFn())
 	engine.GET("/test", func(c *gin.Context) {
-		_ = c.Error(ErrBadRequest.NewWithNoMessage())
+		Error(c, ErrBadRequest.NewWithNoMessage())
 		// If normal response is returned, no error message will be generated
-		c.JSON(http.StatusNotFound, gin.H{
-			"foo": "bar",
-		})
+		c.String(http.StatusNotFound, "foobar")
 	})
 
 	r := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/test", nil)
 	engine.ServeHTTP(r, req)
 	suite.Require().Equal(http.StatusNotFound, r.Code)
-	suite.Require().JSONEq(`{"foo":"bar"}`, r.Body.String())
+	suite.Require().Equal(`foobar`, r.Body.String())
 }
 
 func (suite *ErrorHandlerFnTestSuite) TestNextMiddleware() {
@@ -138,7 +136,7 @@ func (suite *ErrorHandlerFnTestSuite) TestNextMiddleware() {
 		middlewareCalled.Store(true)
 	})
 	engine.GET("/test", func(c *gin.Context) {
-		_ = c.Error(ErrBadRequest.NewWithNoMessage())
+		Error(c, ErrBadRequest.NewWithNoMessage())
 	})
 
 	r := httptest.NewRecorder()

--- a/util/rest/fileswap/server.go
+++ b/util/rest/fileswap/server.go
@@ -90,7 +90,7 @@ func (s *Handler) parseClaimsFromToken(tokenString string) (*downloadTokenClaims
 func (s *Handler) HandleDownloadRequest(c *gin.Context) {
 	claims, err := s.parseClaimsFromToken(c.Query("token"))
 	if err != nil {
-		_ = c.Error(rest.ErrBadRequest.Wrap(err, "Invalid download request"))
+		rest.Error(c, rest.ErrBadRequest.Wrap(err, "Invalid download request"))
 		return
 	}
 
@@ -98,9 +98,9 @@ func (s *Handler) HandleDownloadRequest(c *gin.Context) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			// It is possible that token is reused. In this case, raise invalid request error.
-			_ = c.Error(rest.ErrBadRequest.Wrap(err, "Download file not found. Please retry."))
+			rest.Error(c, rest.ErrBadRequest.Wrap(err, "Download file not found. Please retry."))
 		} else {
-			_ = c.Error(err)
+			rest.Error(c, err)
 		}
 		return
 	}
@@ -116,7 +116,7 @@ func (s *Handler) HandleDownloadRequest(c *gin.Context) {
 		Key: s.secret,
 	})
 	if err != nil {
-		_ = c.Error(err)
+		rest.Error(c, err)
 		return
 	}
 }


### PR DESCRIPTION
This is extracted from https://github.com/pingcap/tidb-dashboard/pull/1148

Changes:

1. Introduce a `jsonserde` package. Unlike the std json serialization/deserialization, it transforms key into json names in snake_case by default, without the need to specify a `json` tag.

   Example:

   ```go
   type example struct {
       FooBar string
   }
   ```

   When serialized using std `json.Marshal`, the produced json looks like:

   ```go
   {"FooBar": "..."}
   ```

   When serialized using `jsonserde.Default.Marshal`, the produced json looks like:

   ```go
   {"foo_bar": "..."}
   ```

   Additionally, `time.Time` will be serialized/deserialized as a millisecond timestamp (instead of a string in std).

   However, as a primitive utility, you should not use it directly. See common helpers below.

2. Introduce `rest.OK`, `rest.JSON`

   These two functions will produce a JSON string using snake_case by default (based on the `jsonserde`).

   Previous:

   ```go
   c.JSON(http.StatusOK, ...)
   ```

   New:

   ```go
   rest.OK(c, ...)
   ```

   Note: To ensure compatibility, I recommend to replace `c.JSON` into `rest.OK` only for newly transited applications. **Do not blindly replace them globally!** For this reason, as you can see, these two functions are not used in this PR.

3. Introduce `rest.MustBind`

   This is the `jsonserde` replacement for `c.ShouldBind`. It binds the request body with the structure you assigned using snake_case. It also returns error by default.

   Note: To ensure compatibility, I recommend to use `c.MustBind` only for newly transited applications. **Do not blindly replace them globally!** For this reason, as you can see, this function is not used in this PR.

   A typical example of new handlers:

```go
func (s *View) GetBundle(c *gin.Context) {
	var req GetBundleReq
	if !rest.MustBind(c, &req) {
		return
	}
	ret, err := s.model.GetBundle(req)
	if err != nil {
		rest.Error(c, err)
		return
	}
	rest.OK(c, ret)
}
```

4. Introduce `rest.Error`

   This is an improved version for the current `_ = c.Error(err)`, that it records the caller stack by default. In this way, when the error is printed out, the error stack will be correct.

   **You should not use `_ = c.Error(err)` any more after this PR. You should use `rest.Error(c, err)`.**

5. Attach the stack into the error detail message when error is not produced by errorx

   In the current implementation there is a bug that, when error is produced by `fmt.Errorf`, the error stack got lost and will not be printed to user. This PR fixes it.

6. Log errors when it is responded to the user

   When the server respond any errors to the user, the errors will be printed in the log as well, for easier troubleshooting.