### PR TITLE
fix: conProf Profile URL

### DIFF
--- a/ui/lib/apps/ContinuousProfiling/pages/Detail.tsx
+++ b/ui/lib/apps/ContinuousProfiling/pages/Detail.tsx
@@ -109,7 +109,7 @@ export default function Page() {
         // view flamegraph by speedscope
         const speedscopeTitle = `${rec.target?.component}_${rec.target?.address}_${rec.profile_type}`
         const profileURL = `${client.getBasePath()}/continuous_profiling/single_profile/view?token=${token}`
-        const speedscopeURL = `${publicPathPrefix}/speedscope#profileURL=${encodeURIComponent(
+        const speedscopeURL = `${publicPathPrefix}/speedscope/#profileURL=${encodeURIComponent(
           profileURL
         )}&title=${speedscopeTitle}`
         window.open(speedscopeURL, '_blank')


### PR DESCRIPTION
The issue is:

Two different profiling results of one component have same Flame Graph on Speedscope, this caused by the same issue, which had been fixed [here](https://github.com/pingcap/tidb-dashboard/pull/1123).