### PR TITLE
fix: solve overflow doesn't work on FireFox

### DIFF
--- a/ui/lib/components/Descriptions/index.module.less
+++ b/ui/lib/components/Descriptions/index.module.less
@@ -49,4 +49,10 @@
   white-space: normal;
   text-overflow: inherit;
   overflow: auto;
+
+  :global {
+    .ant-descriptions-item-container {
+      overflow: auto;
+    }
+  }
 }


### PR DESCRIPTION
Since the `<pre>` tag is inside a table row, and `overflow: auto` not working in table when using FireFox, we need to add a div inside table td with attribute `overflow: auto`. 

![image](https://user-images.githubusercontent.com/34967660/163959354-6cd74b8f-84b0-4ec7-958a-042015919a4b.png)

A reference about this issue can be checked [here](https://stackoverflow.com/questions/16328233/overflow-auto-does-not-work-in-firefox).