### PR TITLE
feat: Sticky submission area for Settings forms

### DIFF
--- a/ui/lib/apps/ContinuousProfiling/pages/ConProfSettingForm.tsx
+++ b/ui/lib/apps/ContinuousProfiling/pages/ConProfSettingForm.tsx
@@ -19,7 +19,7 @@ import client, {
   ConprofContinuousProfilingConfig,
 } from '@lib/client'
 import { useClientRequest } from '@lib/utils/useClientRequest'
-import { ErrorBar, InstanceSelect } from '@lib/components'
+import { DrawerFooter, ErrorBar, InstanceSelect } from '@lib/components'
 import { useIsWriteable } from '@lib/utils/store'
 import { telemetry } from '../utils/telemetry'
 
@@ -187,7 +187,7 @@ function ConProfSettingForm({ onClose, onConfigUpdated }: Props) {
               )
             }
           </Form.Item>
-          <Form.Item>
+          <DrawerFooter>
             <Space>
               <Button
                 type="primary"
@@ -201,7 +201,7 @@ function ConProfSettingForm({ onClose, onConfigUpdated }: Props) {
                 {t('statement.settings.actions.cancel')}
               </Button>
             </Space>
-          </Form.Item>
+          </DrawerFooter>
         </Form>
       )}
     </>

--- a/ui/lib/apps/KeyViz/components/KeyVizSettingForm.tsx
+++ b/ui/lib/apps/KeyViz/components/KeyVizSettingForm.tsx
@@ -13,7 +13,7 @@ import { ExclamationCircleOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import client from '@lib/client'
 import { useClientRequest } from '@lib/utils/useClientRequest'
-import { ErrorBar } from '@lib/components'
+import { DrawerFooter, ErrorBar } from '@lib/components'
 import { useIsWriteable } from '@lib/utils/store'
 
 const policyConfigurable = process.env.NODE_ENV === 'development'
@@ -183,7 +183,7 @@ function KeyVizSettingForm({ onClose, onConfigUpdated }: Props) {
               )
             }}
           </Form.Item>
-          <Form.Item>
+          <DrawerFooter>
             <Space>
               <Button
                 type="primary"
@@ -197,7 +197,7 @@ function KeyVizSettingForm({ onClose, onConfigUpdated }: Props) {
                 {t('keyviz.settings.actions.cancel')}
               </Button>
             </Space>
-          </Form.Item>
+          </DrawerFooter>
         </Form>
       )}
     </>

--- a/ui/lib/apps/Statement/pages/List/StatementSettingForm.tsx
+++ b/ui/lib/apps/Statement/pages/List/StatementSettingForm.tsx
@@ -13,7 +13,7 @@ import { ExclamationCircleOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import client, { StatementEditableConfig } from '@lib/client'
 import { useClientRequest } from '@lib/utils/useClientRequest'
-import { ErrorBar } from '@lib/components'
+import { DrawerFooter, ErrorBar } from '@lib/components'
 import { useIsWriteable } from '@lib/utils/store'
 
 interface Props {
@@ -195,7 +195,7 @@ function StatementSettingForm({ onClose, onConfigUpdated }: Props) {
               )
             }
           </Form.Item>
-          <Form.Item>
+          <DrawerFooter>
             <Space>
               <Button
                 type="primary"
@@ -210,7 +210,7 @@ function StatementSettingForm({ onClose, onConfigUpdated }: Props) {
                 {t('statement.settings.actions.cancel')}
               </Button>
             </Space>
-          </Form.Item>
+          </DrawerFooter>
         </Form>
       )}
     </>

--- a/ui/lib/apps/TopSQL/pages/List/SettingsForm.tsx
+++ b/ui/lib/apps/TopSQL/pages/List/SettingsForm.tsx
@@ -4,7 +4,7 @@ import { ExclamationCircleOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import client, { TopsqlEditableConfig } from '@lib/client'
 import { useClientRequest } from '@lib/utils/useClientRequest'
-import { ErrorBar } from '@lib/components'
+import { DrawerFooter, ErrorBar } from '@lib/components'
 import { useIsWriteable } from '@lib/utils/store'
 import { telemetry } from '../../utils/telemetry'
 
@@ -80,7 +80,7 @@ export function SettingsForm({ onClose, onConfigUpdated }: Props) {
               <Switch disabled={!isWriteable} />
             </Form.Item>
           </Form.Item>
-          <Form.Item>
+          <DrawerFooter>
             <Space>
               <Button
                 type="primary"
@@ -94,7 +94,7 @@ export function SettingsForm({ onClose, onConfigUpdated }: Props) {
                 {t('topsql.settings.actions.cancel')}
               </Button>
             </Space>
-          </Form.Item>
+          </DrawerFooter>
         </Form>
       )}
     </>

--- a/ui/lib/components/DrawerFooter/index.module.less
+++ b/ui/lib/components/DrawerFooter/index.module.less
@@ -1,0 +1,19 @@
+@import 'antd/es/style/themes/default.less';
+
+.container {
+  position: sticky;
+  bottom: -@drawer-body-padding;
+  margin: -@drawer-body-padding;
+  background: @drawer-bg;
+  padding: @drawer-body-padding;
+
+  transition: box-shadow 0.1s linear;
+
+  &.withShadow {
+    box-shadow: 0 -5px 10px rgba(#000, 0.1);
+  }
+}
+
+.mark {
+  height: 1px;
+}

--- a/ui/lib/components/DrawerFooter/index.tsx
+++ b/ui/lib/components/DrawerFooter/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { useInView } from 'react-intersection-observer'
+import cx from 'classnames'
+
+import styles from './index.module.less'
+
+// A sticky footer for Antd Drawer component.
+function DrawerFooter({
+  children,
+  className,
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement>) {
+  const { ref, inView } = useInView({
+    initialInView: true, // prevent shadow being displayed at the beginning
+    rootMargin: '-24px', // equals to @drawer-body-padding
+  })
+  const displayShadow = !inView
+
+  return (
+    <>
+      <div
+        className={cx(className, styles.container, {
+          [styles.withShadow]: displayShadow,
+        })}
+        {...rest}
+      >
+        {children}
+      </div>
+      <div ref={ref} className={styles.mark}></div>
+    </>
+  )
+}
+
+export default React.memo(DrawerFooter)

--- a/ui/lib/components/index.ts
+++ b/ui/lib/components/index.ts
@@ -55,6 +55,8 @@ export * from './Blink'
 export { default as Blink } from './Blink'
 export * from './ActionsButton'
 export { default as ActionsButton } from './ActionsButton'
+export * from './DrawerFooter'
+export { default as DrawerFooter } from './DrawerFooter'
 
 export { default as LanguageDropdown } from './LanguageDropdown'
 export { default as ParamsPageWrapper } from './ParamsPageWrapper'

--- a/ui/package.json
+++ b/ui/package.json
@@ -52,6 +52,7 @@
     "react-error-boundary": "^3.1.4",
     "react-highlight-words": "^0.16.0",
     "react-i18next": "^11.7.0",
+    "react-intersection-observer": "^9.1.0",
     "react-markdown": "^7.1.0",
     "react-router": "^6.0.0-alpha.3",
     "react-router-dom": "^6.0.0-alpha.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10371,6 +10371,11 @@ react-i18next@^11.7.0:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"
 
+react-intersection-observer@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.1.0.tgz#27e66be9113fdf6fc6d745e849e1ad6ef20f97f1"
+  integrity sha512-XSDWQGzgJ4/B4eW39+qa3S+uc4Gb+m6lxXR54m/uD5lqeL5sLrgYdntbjl4BlTYAblgUhz+JB5obINhZaD+c0Q==
+
 react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
When settings form overflows:
<img width="313" alt="image" src="https://user-images.githubusercontent.com/1916485/166618182-d6d2b8c1-9c60-457b-ae6b-cde961665343.png">

When settings form overflows and scrolled to the bottom:
<img width="319" alt="image" src="https://user-images.githubusercontent.com/1916485/166618192-128af4f3-f580-4828-8df7-8b234917e3ab.png">

When settings form does not overflow:
<img width="311" alt="image" src="https://user-images.githubusercontent.com/1916485/166618204-812ca2f2-861b-4ad1-a586-e363bcd0148f.png">
