### PR TITLE
feat: enlarge log display area

### DIFF
--- a/ui/lib/apps/SearchLogs/components/SearchProgress.tsx
+++ b/ui/lib/apps/SearchLogs/components/SearchProgress.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { getValueFormat } from '@baurine/grafana-value-formats'
 
 import client, { LogsearchTaskModel } from '@lib/client'
-import { AnimatedSkeleton, Card } from '@lib/components'
+import { AnimatedSkeleton } from '@lib/components'
 import { FailIcon, LoadingIcon, SuccessIcon } from './Icon'
 import { TaskState } from '../utils'
 
@@ -188,55 +188,47 @@ export default function SearchProgress({
   }, [])
 
   return (
-    <Card
-      id="search_progress"
-      style={{ marginLeft: -48 }}
-      title={t('search_logs.common.progress')}
-    >
-      <AnimatedSkeleton showSkeleton={isLoading}>
-        {tasks && (
-          <>
-            <div>{describeProgress(tasks)}</div>
-            <div className={styles.buttons}>
-              <Button
-                type="primary"
-                onClick={handleDownload}
-                disabled={checkedKeys.length < 1}
-              >
-                {t('search_logs.common.download_selected')}
-              </Button>
-              <Button
-                danger
-                onClick={handleCancel}
-                disabled={
-                  !tasks.some((task) => task.state === TaskState.Running)
-                }
-              >
-                {t('search_logs.common.cancel')}
-              </Button>
-              <Button
-                onClick={handleRetry}
-                disabled={
-                  tasks.some((task) => task.state === TaskState.Running) ||
-                  !tasks.some((task) => task.state === TaskState.Error)
-                }
-              >
-                {t('search_logs.common.retry')}
-              </Button>
-            </div>
-            <Tree
-              checkable
-              expandedKeys={[...InstanceKinds]}
-              selectable={false}
-              defaultExpandAll
-              showIcon
-              onCheck={handleCheck}
-              style={{ overflowX: 'hidden' }}
-              treeData={treeData}
-            />
-          </>
-        )}
-      </AnimatedSkeleton>
-    </Card>
+    <AnimatedSkeleton showSkeleton={isLoading}>
+      {tasks && (
+        <>
+          <div>{describeProgress(tasks)}</div>
+          <div className={styles.buttons}>
+            <Button
+              type="primary"
+              onClick={handleDownload}
+              disabled={checkedKeys.length < 1}
+            >
+              {t('search_logs.common.download_selected')}
+            </Button>
+            <Button
+              danger
+              onClick={handleCancel}
+              disabled={!tasks.some((task) => task.state === TaskState.Running)}
+            >
+              {t('search_logs.common.cancel')}
+            </Button>
+            <Button
+              onClick={handleRetry}
+              disabled={
+                tasks.some((task) => task.state === TaskState.Running) ||
+                !tasks.some((task) => task.state === TaskState.Error)
+              }
+            >
+              {t('search_logs.common.retry')}
+            </Button>
+          </div>
+          <Tree
+            checkable
+            expandedKeys={[...InstanceKinds]}
+            selectable={false}
+            defaultExpandAll
+            showIcon
+            onCheck={handleCheck}
+            style={{ overflowX: 'hidden' }}
+            treeData={treeData}
+          />
+        </>
+      )}
+    </AnimatedSkeleton>
   )
 }

--- a/ui/lib/apps/SearchLogs/pages/LogSearchDetail.tsx
+++ b/ui/lib/apps/SearchLogs/pages/LogSearchDetail.tsx
@@ -1,6 +1,6 @@
-import { Col, Row } from 'antd'
+import { Button, Drawer } from 'antd'
 import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane'
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { ArrowLeftOutlined } from '@ant-design/icons'
@@ -16,6 +16,8 @@ export default function LogSearchingDetail() {
   const { t } = useTranslation()
   const { id } = useQueryParams()
   const [reloadKey, setReloadKey] = useState(false)
+  const [taskWasUnfinished, setTaskUnfinished] = useState(false)
+  const [sidebarOpen, setSidebarOpen] = useState<boolean | undefined>(undefined)
 
   function toggleReload() {
     setReloadKey(!reloadKey)
@@ -45,10 +47,18 @@ export default function LogSearchingDetail() {
 
   const tasks = useMemo(() => data?.tasks ?? [], [data])
 
+  useEffect(() => {
+    for (const task of data?.tasks ?? []) {
+      if (task.state !== TaskState.Finished) {
+        setTaskUnfinished(true)
+        break
+      }
+    }
+  }, [data])
+
   return (
-    <Row>
-      <Col
-        span={18}
+    <>
+      <div
         style={{
           display: 'flex',
           flexDirection: 'column',
@@ -61,6 +71,11 @@ export default function LogSearchingDetail() {
             <Link to={`/search_logs`}>
               <ArrowLeftOutlined /> {t('search_logs.nav.search_logs')}
             </Link>
+          }
+          titleExtra={
+            <Button type="primary" onClick={() => setSidebarOpen(true)}>
+              {t('search_logs.nav.show_sidebar')}
+            </Button>
           }
         ></Head>
         <div style={{ height: '100%', position: 'relative', marginRight: 4 }}>
@@ -75,15 +90,21 @@ export default function LogSearchingDetail() {
             />
           </ScrollablePane>
         </div>
-      </Col>
-      <Col span={6}>
+      </div>
+      <Drawer
+        mask={false}
+        visible={sidebarOpen ?? taskWasUnfinished}
+        width={350}
+        title={t('search_logs.common.progress')}
+        onClose={() => setSidebarOpen(false)}
+      >
         <SearchProgress
           key={`${reloadKey}`}
           toggleReload={toggleReload}
           taskGroupID={taskGroupID}
           tasks={tasks}
         />
-      </Col>
-    </Row>
+      </Drawer>
+    </>
   )
 }

--- a/ui/lib/apps/SearchLogs/translations/en.yaml
+++ b/ui/lib/apps/SearchLogs/translations/en.yaml
@@ -4,6 +4,7 @@ search_logs:
     search_logs: Search Logs
     detail: Search Result
     history: History
+    show_sidebar: Download or Show Progress
   page:
     intro: Preview and download logs by clicking Search
     tip: The preview shows only the first 500 logs

--- a/ui/lib/apps/SearchLogs/translations/zh.yaml
+++ b/ui/lib/apps/SearchLogs/translations/zh.yaml
@@ -4,6 +4,7 @@ search_logs:
     search_logs: 日志搜索
     detail: 搜索结果
     history: 历史搜索
+    show_sidebar: 下载或显示进度
   page:
     intro: 点击搜索预览和下载日志
     tip: 预览仅显示前 500 项日志


### PR DESCRIPTION
Now it is possible to view logs in nearly full screen:

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/1916485/167421825-00a77bfa-1bb4-4994-9edb-711888d4e62b.png">
