### PR TITLE
feat: select all profiling types and instances by default

### DIFF
--- a/ui/lib/apps/InstanceProfiling/pages/List.tsx
+++ b/ui/lib/apps/InstanceProfiling/pages/List.tsx
@@ -85,12 +85,14 @@ export default function Page() {
         })
         .filter((i) => i.port != null)
 
+      // Default to all types if non is selected
+      const types = !fieldsValue.type?.length
+        ? [...profilingTypeOptions]
+        : fieldsValue.type
       const req: ProfilingStartRequest = {
         targets,
         duration_secs: fieldsValue.duration,
-        requsted_profiling_types: fieldsValue.type.map((type) =>
-          type.toLowerCase()
-        ),
+        requsted_profiling_types: types.map((type) => type.toLowerCase()),
       }
       try {
         setSubmitting(true)
@@ -205,11 +207,12 @@ export default function Page() {
           initialValues={{
             instances: [],
             duration: defaultProfilingDuration,
+            type: [],
           }}
         >
           <Form.Item
             name="instances"
-            label={t('instance_profiling.list.control_form.instances.label')}
+            // label={t('instance_profiling.list.control_form.instances.label')}
             rules={[{ required: true }]}
           >
             <InstanceSelect
@@ -217,15 +220,10 @@ export default function Page() {
               enableTiFlash={true}
               ref={instanceSelect}
               style={{ width: 200 }}
+              defaultSelectAll
             />
           </Form.Item>
-          <Form.Item
-            name="type"
-            label={t(
-              'instance_profiling.list.control_form.profiling_type.label'
-            )}
-            rules={[{ required: true }]}
-          >
+          <Form.Item name="type">
             <MultiSelect.Plain
               disabled={conprofEnable}
               placeholder={t(

--- a/ui/lib/apps/InstanceProfiling/translations/en.yaml
+++ b/ui/lib/apps/InstanceProfiling/translations/en.yaml
@@ -5,11 +5,8 @@ instance_profiling:
   list:
     control_form:
       title: Start Profiling Instances
-      instances:
-        label: Select instances
       profiling_type:
-        label: Select Profiling Type
-        placeholder: Select Profiling Type
+        placeholder: All Profiling Types
         columnTitle: Profiling Type
       duration:
         label: Duration

--- a/ui/lib/apps/InstanceProfiling/translations/zh.yaml
+++ b/ui/lib/apps/InstanceProfiling/translations/zh.yaml
@@ -5,12 +5,9 @@ instance_profiling:
   list:
     control_form:
       title: 开始性能分析
-      instances:
-        label: 选择实例
       profiling_type:
-        label: 选择分析类型
-        placeholder: 选择分析类型
-        columnTitle: 分析类型
+        placeholder: 所有性能数据
+        columnTitle: 性能数据类型
       duration:
         label: 分析时长
       submit: 开始分析

--- a/ui/lib/components/InstanceSelect/DropOverlay.tsx
+++ b/ui/lib/components/InstanceSelect/DropOverlay.tsx
@@ -37,7 +37,7 @@ function DropOverlay({
   const { style: containerStyle, ...restContainerProps } = containerProps ?? {}
   const finalContainerProps = useMemo(() => {
     const style: React.CSSProperties = {
-      fontSize: '0.8rem',
+      fontSize: '0.9rem',
       ...containerStyle,
     }
     return {

--- a/ui/lib/components/MultiSelect/DropOverlay.tsx
+++ b/ui/lib/components/MultiSelect/DropOverlay.tsx
@@ -7,7 +7,7 @@ import TableWithFilter, {
 import { IItem } from '.'
 
 const containerProps: React.HTMLAttributes<HTMLDivElement> = {
-  style: { fontSize: '0.8rem' },
+  style: { fontSize: '0.9rem' },
 }
 
 export interface IDropOverlayProps<T> {


### PR DESCRIPTION
User only needs to click "Start Profiling"! No need to select multiple options any more.

<img width="1499" alt="image" src="https://user-images.githubusercontent.com/1916485/167425995-7ab35ae8-eb3a-46b3-bc83-fe7c880fffad.png">

This is a small feature extracted from https://github.com/pingcap/tidb-dashboard/pull/1148
