### PR TITLE
add QPS in tidb_dashboard ref:#1209

### DIFF
--- a/pkg/keyvisual/input/api.go
+++ b/pkg/keyvisual/input/api.go
@@ -29,6 +29,8 @@ type RegionInfo struct {
 	ReadBytes       uint64 `json:"read_bytes"`
 	WrittenKeys     uint64 `json:"written_keys"`
 	ReadKeys        uint64 `json:"read_keys"`
+	WriteQueryNum   uint64 `json:"write_query_num"`
+	ReadQueryNum    uint64 `json:"read_query_num"`
 	ApproximateSize int64  `json:"approximate_size"`
 	ApproximateKeys int64  `json:"approximate_keys"`
 }
@@ -71,6 +73,14 @@ func (rs *RegionsInfo) GetValues(tag regionpkg.StatTag) []uint64 {
 	case regionpkg.ReadKeys:
 		for i, region := range rs.Regions {
 			values[i] = region.ReadKeys
+		}
+	case regionpkg.WriteQueryNum:
+		for i, region := range rs.Regions {
+			values[i] = region.WriteQueryNum
+		}
+	case regionpkg.ReadQueryNum:
+		for i, region := range rs.Regions {
+			values[i] = region.ReadQueryNum
 		}
 	case regionpkg.Integration:
 		for i, region := range rs.Regions {

--- a/pkg/keyvisual/region/tag.go
+++ b/pkg/keyvisual/region/tag.go
@@ -16,6 +16,10 @@ const (
 	WrittenKeys
 	// ReadKeys is the number of keys read to the data per minute.
 	ReadKeys
+	// WriteQueryNum is write query num from this region
+	WriteQueryNum
+	// ReadQueryNum is read query num from this region
+	ReadQueryNum
 )
 
 // IntoTag converts a string into a StatTag.
@@ -33,6 +37,10 @@ func IntoTag(typ string) StatTag {
 		return WrittenKeys
 	case "read_keys":
 		return ReadKeys
+	case "write_query_num":
+		return WriteQueryNum
+	case "read_query_num":
+		return ReadQueryNum
 	default:
 		return WrittenBytes
 	}
@@ -50,13 +58,17 @@ func (tag StatTag) String() string {
 		return "written_keys"
 	case ReadKeys:
 		return "read_keys"
+	case WriteQueryNum:
+		return "write_query_num"
+	case ReadQueryNum:
+		return "read_query_num"
 	default:
 		panic("unreachable")
 	}
 }
 
 // StorageTags is the order of tags during storage.
-var StorageTags = []StatTag{WrittenBytes, ReadBytes, WrittenKeys, ReadKeys}
+var StorageTags = []StatTag{WrittenBytes, ReadBytes, WrittenKeys, ReadKeys, WriteQueryNum, ReadQueryNum}
 
 // ResponseTags is the order of tags when responding.
 var ResponseTags = append([]StatTag{Integration}, StorageTags...)

--- a/pkg/keyvisual/service.go
+++ b/pkg/keyvisual/service.go
@@ -222,7 +222,7 @@ func (s *Service) Stop(ctx context.Context) error {
 // @Param endkey query string false "The end of the key range"
 // @Param starttime query int false "The start of the time range (Unix)"
 // @Param endtime query int false "The end of the time range (Unix)"
-// @Param type query string false "Main types of data" Enums(written_bytes, read_bytes, written_keys, read_keys, integration)
+// @Param type query string false "Main types of data" Enums(written_bytes, read_bytes, written_keys, read_keys, write_query_num, read_query_num, integration)
 // @Success 200 {object} matrix.Matrix
 // @Router /keyvisual/heatmaps [get]
 // @Security JwtAuth

--- a/ui/lib/apps/KeyViz/components/KeyVizToolbar.tsx
+++ b/ui/lib/apps/KeyViz/components/KeyVizToolbar.tsx
@@ -94,6 +94,14 @@ class KeyVizToolbar extends Component<IKeyVizToolbarProps & WithTranslation> {
       },
       { text: t('keyviz.toolbar.view_type.read_keys'), value: 'read_keys' },
       { text: t('keyviz.toolbar.view_type.write_keys'), value: 'written_keys' },
+      {
+        text: t('keyviz.toolbar.view_type.read_query_num'),
+        value: 'read_query_num',
+      },
+      {
+        text: t('keyviz.toolbar.view_type.write_query_num'),
+        value: 'write_query_num',
+      },
       { text: t('keyviz.toolbar.view_type.all'), value: 'integration' },
     ]
 

--- a/ui/lib/apps/KeyViz/heatmap/types.ts
+++ b/ui/lib/apps/KeyViz/heatmap/types.ts
@@ -9,6 +9,8 @@ export type DataTag =
   | 'read_bytes'
   | 'written_keys'
   | 'read_keys'
+  | `write_query_num`
+  | `read_query_num`
 
 export type HeatmapRange = {
   starttime?: number

--- a/ui/lib/apps/KeyViz/heatmap/utils.ts
+++ b/ui/lib/apps/KeyViz/heatmap/utils.ts
@@ -14,6 +14,10 @@ export function tagUnit(tag: DataTag): string {
       return 'keys/min'
     case 'written_keys':
       return 'keys/min'
+    case 'read_query_num':
+      return 'qps/min'
+    case 'write_query_num':
+      return 'qps/min'
   }
 }
 

--- a/ui/lib/apps/KeyViz/translations/en.yaml
+++ b/ui/lib/apps/KeyViz/translations/en.yaml
@@ -10,6 +10,8 @@ keyviz:
       write_bytes: Write (bytes)
       read_keys: Read (keys)
       write_keys: Write (keys)
+      read_query_num: Read(qps)
+      write_query_num: Write(qps)
       all: All
   settings:
     title: Settings

--- a/ui/lib/apps/KeyViz/translations/zh.yaml
+++ b/ui/lib/apps/KeyViz/translations/zh.yaml
@@ -10,6 +10,8 @@ keyviz:
       write_bytes: 写入字节量
       read_keys: 读取次数
       write_keys: 写入次数
+      read_query_num: 读查询次数
+      write_query_num: 写查询次数
       all: 所有
   settings:
     title: 设置


### PR DESCRIPTION
Signed-off-by: qidi1 <1083369179@qq.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Currently，Keyviz has `keys` and `bytes` dimensions. In some situations, it cannot find the hotspot that the CPU is high caused by QPS, the `keys` and `bytes` may be 0. For example:

```sql
create table t(id int);
insert into table t values (1)(2)....(1000);
// random read out bound，suppose there are many requests.
select * from t where id = 1000 + rand(0,1000)
```

## 
Issue Number:  #1209
### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
 Return QPS data in PD.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test 


Related changes
- https://github.com/tikv/pd/pull/4922
- https://github.com/tikv/pd/pull/4921
- https://github.com/pingcap/kvproto/pull/914
### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```

## Manual test
We ran a small cluster locally. On the cluster, test data was generated using the tiup bench tool. The results are shown in the figure below.
![image](https://user-images.githubusercontent.com/38561029/167781781-8c1a0c60-5604-49c7-9efb-f8a2a779beb1.png)
![image](https://user-images.githubusercontent.com/38561029/167781794-d9c2c352-57d2-4594-9de3-58f5d7675c6d.png)


