### PR TITLE
script: ignore non-formal pd tags

### DIFF
--- a/scripts/pd_version_matrix.go
+++ b/scripts/pd_version_matrix.go
@@ -105,6 +105,9 @@ func main() {
 
 	pdTags := listPDTags()
 	for _, pdTag := range pdTags {
+		if strings.Count(pdTag, "-") > 0 {
+			continue
+		}
 		if semver.Compare(pdTag, "v4.0.0") < 0 {
 			continue
 		}


### PR DESCRIPTION
This ignores tags such as "v1.2.3-rc" in the [Version Matrix](https://github.com/pingcap/tidb-dashboard/wiki/TiDB-Dashboard-×-PD-Version-Matrix).