### PR TITLE
ui: Add help link for ngm error

### DIFF
--- a/ui/dashboardApp/index.tsx
+++ b/ui/dashboardApp/index.tsx
@@ -10,7 +10,7 @@ import AppRegistry from '@lib/utils/registry'
 import * as routing from '@lib/utils/routing'
 import * as auth from '@lib/utils/auth'
 import * as i18n from '@lib/utils/i18n'
-import { distro } from '@lib/utils/i18n'
+import { distro, isDistro } from '@lib/utils/i18n'
 import { saveAppOptions, loadAppOptions } from '@lib/utils/appOptions'
 import {
   initSentryRoutingInstrument,
@@ -44,6 +44,7 @@ import { mustLoadAppInfo, reloadWhoAmI, NgmState } from '@lib/utils/store'
 // NOTE: Don't remove above comment line, it is a placeholder for code generator
 
 import translations from './layout/translations'
+import React from 'react'
 
 function removeSpinner() {
   const spinner = document.getElementById('dashboard_page_spinner')
@@ -100,7 +101,23 @@ async function webPageStart() {
     notification.error({
       key: 'ngm_not_started',
       message: i18next.t('health_check.failed_notification_title'),
-      description: i18next.t('health_check.ngm_not_started'),
+      description: (
+        <span>
+          {i18next.t('health_check.ngm_not_started')}
+          {Boolean(!isDistro) && (
+            <>
+              {' '}
+              <a
+                href={i18next.t('health_check.help_url')}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {i18next.t('health_check.help_text')}
+              </a>
+            </>
+          )}
+        </span>
+      ),
       duration: null,
     })
   }

--- a/ui/dashboardApp/layout/translations/en.yaml
+++ b/ui/dashboardApp/layout/translations/en.yaml
@@ -37,3 +37,5 @@ nav:
 health_check:
   failed_notification_title: System Health Check Failed
   ngm_not_started: A required component `NgMonitoring` is not started in this cluster. Some features may not work.
+  help_text: Help
+  help_url: https://docs.pingcap.com/tidb/dev/dashboard-faq#a-required-component-ngmonitoring-is-not-started-error-is-shown

--- a/ui/dashboardApp/layout/translations/zh.yaml
+++ b/ui/dashboardApp/layout/translations/zh.yaml
@@ -38,3 +38,5 @@ nav:
 health_check:
   failed_notification_title: 系统健康检查失败
   ngm_not_started: 集群中未启动必要组件 `NgMonitoring`，部分功能将不可用。
+  help_text: 帮助
+  help_url: https://docs.pingcap.com/zh/tidb/dev/dashboard-faq#界面提示-集群中未启动必要组件-ngmonitoring

--- a/ui/lib/apps/Ngm/components/Error/NgmNotStarted.tsx
+++ b/ui/lib/apps/Ngm/components/Error/NgmNotStarted.tsx
@@ -1,10 +1,10 @@
 // Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 import React, { ReactNode } from 'react'
-import { Result } from 'antd'
+import { Button, Result, Space } from 'antd'
 import { useTranslation } from 'react-i18next'
 
 import { Card } from '@lib/components'
-import { addTranslationResource } from '@lib/utils/i18n'
+import { addTranslationResource, isDistro } from '@lib/utils/i18n'
 import { useNgmState, NgmState } from '@lib/utils/store'
 
 const translations = {
@@ -12,10 +12,16 @@ const translations = {
     title: 'Feature Not Enabled',
     subTitle:
       'A required component `NgMonitoring` is not started in this cluster. This feature is not available.',
+    help_text: 'Help',
+    help_url:
+      'https://docs.pingcap.com/tidb/dev/dashboard-faq#a-required-component-ngmonitoring-is-not-started-error-is-shown',
   },
   zh: {
     title: '该功能未启用',
     subTitle: '集群中未启动必要组件 `NgMonitoring`，本功能不可用。',
+    help_text: '帮助',
+    help_url:
+      'https://docs.pingcap.com/zh/tidb/dev/dashboard-faq#界面提示-集群中未启动必要组件-ngmonitoring',
   },
 }
 
@@ -34,6 +40,19 @@ export function NgmNotStarted() {
       <Result
         title={t('component.ngmNotStarted.title')}
         subTitle={t('component.ngmNotStarted.subTitle')}
+        extra={
+          <Space>
+            {!isDistro && (
+              <Button
+                onClick={() => {
+                  window.open(t('component.ngmNotStarted.help_url'), '_blank')
+                }}
+              >
+                {t('component.ngmNotStarted.help_text')}
+              </Button>
+            )}
+          </Space>
+        }
       />
     </Card>
   )


### PR DESCRIPTION
This change will be carried in v6.1.1.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/1916485/173278997-37a0563d-c4d4-47a0-b330-9ce1bcc464ff.png">
