### PR TITLE
fix: TiDB server disconnection promQL

### DIFF
--- a/ui/packages/tidb-dashboard-for-dbaas/package.json
+++ b/ui/packages/tidb-dashboard-for-dbaas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pingcap/tidb-dashboard-for-dbaas",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "main": "dist/main.js",
   "module": "dist/main.js",
   "files": [

--- a/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/metricsQueries.ts
@@ -154,7 +154,8 @@ const monitoringItems: MetricsQueryType[] = [
         title: 'Disconnection',
         queries: [
           {
-            query: 'sum(tidb_server_disconnection_total) by (instance, result)',
+            query:
+              'sum(rate(tidb_server_disconnection_total[$__rate_interval])) by (instance, result)',
             name: '{instance}-{result}'
           }
         ],

--- a/ui/packages/tidb-dashboard-for-debugportal/package.json
+++ b/ui/packages/tidb-dashboard-for-debugportal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pingcap/tidb-dashboard-for-debugportal",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "dist/dashboardApp.js",
   "module": "dist/dashboardApp.js",
   "files": [

--- a/ui/packages/tidb-dashboard-for-debugportal/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-debugportal/src/apps/Monitoring/metricsQueries.ts
@@ -154,7 +154,8 @@ const monitoringItems: MetricsQueryType[] = [
         title: 'Disconnection',
         queries: [
           {
-            query: 'sum(tidb_server_disconnection_total) by (instance, result)',
+            query:
+              'sum(rate(tidb_server_disconnection_total[$__rate_interval])) by (instance, result)',
             name: '{instance}-{result}'
           }
         ],

--- a/ui/packages/tidb-dashboard-for-op/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/Monitoring/metricsQueries.ts
@@ -154,7 +154,8 @@ const monitoringItems: MetricsQueryType[] = [
         title: 'Disconnection',
         queries: [
           {
-            query: 'sum(tidb_server_disconnection_total) by (instance, result)',
+            query:
+              'sum(rate(tidb_server_disconnection_total[$__rate_interval])) by (instance, result)',
             name: '{instance}-{result}'
           }
         ],


### PR DESCRIPTION
**What this PR does?**
Update TiDB server disconnection promQL

before:
![image](https://user-images.githubusercontent.com/34967660/185284699-fe47e143-2115-4c2a-a485-4d799053ea62.png)

after:
![image](https://user-images.githubusercontent.com/34967660/185284602-7c84b6d9-b6f1-42db-93d9-a76a71c333ca.png)
