### PR TITLE
fix keyviz tooltip timezone

### DIFF
--- a/ui/packages/tidb-dashboard-for-dbaas/package.json
+++ b/ui/packages/tidb-dashboard-for-dbaas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pingcap/tidb-dashboard-for-dbaas",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "main": "dist/main.js",
   "module": "dist/main.js",
   "files": [

--- a/ui/packages/tidb-dashboard-lib/src/apps/KeyViz/heatmap/chart.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/KeyViz/heatmap/chart.ts
@@ -707,9 +707,12 @@ export async function heatmapChart(
 
       const timeText = [timeIdx, timeIdx + 1]
         .map((idx) =>
-          d3.timeFormat('%Y-%m-%d\n%H:%M:%S')(
-            new Date(data.timeAxis[idx] * 1000)
-          )
+          // d3.timeFormat('%Y-%m-%d\n%H:%M:%S')(
+          //   new Date(data.timeAxis[idx] * 1000)
+          // )
+          dayjs(data.timeAxis[idx as number] * 1000)
+            .utcOffset(tz.getTimeZone())
+            .format('YYYY-MM-DD HH:mm:ss')
         )
         .join(' ~ ')
 


### PR DESCRIPTION

Preview:

time for UTC+00:00 timezone while local time is 17:35

![image](https://user-images.githubusercontent.com/1284531/185890950-1ce9d174-0df1-400b-ba76-99c8bb5b0db0.png)
