### PR TITLE
correct the unit of byte from B to G

### DIFF
--- a/ui/packages/tidb-dashboard-lib/src/components/ValueWithTooltip/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/components/ValueWithTooltip/index.tsx
@@ -36,7 +36,7 @@ function ShortValueWithTooltip({
   )
 }
 
-const bytesScaler = scaledUnits(1024, ['', 'K', 'M', 'B', 'T'])
+const bytesScaler = scaledUnits(1024, ['', 'K', 'M', 'G', 'T'])
 
 function ScaledBytesWithTooltip({
   value = 0,


### PR DESCRIPTION
The component presents the byte unit in the wrong format.

![image](https://user-images.githubusercontent.com/29370032/186407433-bcd93c9a-510a-4b0e-927f-c5cf410c56c7.png)
