### PR TITLE
chore: make tikv storage size version compatible

### DIFF
--- a/ui/packages/tidb-dashboard-for-clinic-cloud/package.json
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pingcap/tidb-dashboard-for-clinic-cloud",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "dist/dashboardApp.js",
   "module": "dist/dashboardApp.js",
   "files": [

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/package.json
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/package.json
@@ -34,6 +34,7 @@
     "axios": "^0.27.2",
     "bulma": "^0.9.4",
     "classnames": "^2.3.1",
+    "compare-versions": "^5.0.1",
     "eventemitter2": "^6.4.5",
     "i18next": "^21.6.11",
     "nprogress": "^0.2.0",

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Monitoring/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Monitoring/context.ts
@@ -6,7 +6,7 @@ import {
 
 import client from '~/client'
 
-import { monitoringItems } from './metricsQueries'
+import { getMonitoringItems } from './metricsQueries'
 
 class DataSource implements IMonitoringDataSource {
   metricsQueryGet(
@@ -33,6 +33,7 @@ const ds = new DataSource()
 export const ctx: IMonitoringContext = {
   ds,
   cfg: {
-    metricsQueries: monitoringItems
+    getMetricsQueries: (pdVersion: string | undefined) =>
+      getMonitoringItems(pdVersion)
   }
 }

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Monitoring/metricsQueries.ts
@@ -48,615 +48,702 @@ function transformColorByExecTimeOverview(legendLabel: string) {
   }
 }
 
-const monitoringItems: MetricsQueryType[] = [
-  {
-    category: 'database_time',
-    metrics: [
-      {
-        title: 'Database Time by SQL Types',
-        queries: [
-          {
-            query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval]))`,
-            name: 'database time',
-            color: ColorType.YELLOW,
-            type: 'line'
-          },
-          {
-            query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) by (sql_type)`,
-            name: '{sql_type}',
-            color: (qd: QueryData) => transformColorBySQLType(qd.name),
-            type: 'bar_stacked'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'mixed'
-      },
-      {
-        title: 'Database Time by SQL Phase',
-        queries: [
-          {
-            query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval]))`,
-            name: 'database time',
-            color: ColorType.YELLOW,
-            type: 'line'
-          },
-          {
-            query: `sum(rate(tidb_session_parse_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
-            name: 'parse',
-            color: ColorType.RED_2,
-            type: 'bar_stacked'
-          },
-          {
-            query: `sum(rate(tidb_session_compile_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
-            name: 'compile',
-            color: ColorType.ORANGE,
-            type: 'bar_stacked'
-          },
-          {
-            query: `sum(rate(tidb_session_execute_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
-            name: 'execute',
-            color: ColorType.GREEN_3,
-            type: 'bar_stacked'
-          },
-          {
-            query: `sum(rate(tidb_server_get_token_duration_seconds_sum[$__rate_interval]))/1000000`,
-            name: 'get token',
-            color: ColorType.RED_3,
-            type: 'bar_stacked'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'mixed'
-      },
-      {
-        title: 'SQL Execute Time Overview',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_tikvclient_request_seconds_sum{store!="0"}[$__rate_interval])) by (type)',
-            name: '{type}',
-            color: (qd: QueryData) => transformColorByExecTimeOverview(qd.name)
-          },
-          {
-            query:
-              'sum(rate(pd_client_cmd_handle_cmds_duration_seconds_sum{type="wait"}[$__rate_interval]))',
-            name: 'tso_wait',
-            color: ColorType.RED_5
-          }
-        ],
-        unit: 's',
-        type: 'bar_stacked'
-      }
-    ]
-  },
-  {
-    category: 'application_connection',
-    metrics: [
-      {
-        title: 'Connection Count',
-        queries: [
-          {
-            query: 'sum(tidb_server_connections)',
-            name: 'Total'
-          },
-          {
-            query: 'sum(tidb_server_tokens)',
-            name: 'active connections'
-          }
-        ],
-        unit: 'short',
-        nullValue: TransformNullValue.AS_ZERO,
-        type: 'line'
-      },
-      {
-        title: 'Disconnection',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_disconnection_total[$__rate_interval])) by (instance, result)',
-            name: '{instance}-{result}'
-          }
-        ],
-        unit: 'short',
-        nullValue: TransformNullValue.AS_ZERO,
-        type: 'area_stack'
-      }
-    ]
-  },
-  {
-    category: 'sql_count',
-    metrics: [
-      {
-        title: 'Query Per Second',
-        queries: [
-          {
-            query: 'sum(rate(tidb_executor_statement_total[$__rate_interval]))',
-            name: 'Total'
-          },
-          {
-            query:
-              'sum(rate(tidb_executor_statement_total[$__rate_interval])) by (type)',
-            name: '{type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'qps',
-        type: 'line'
-      },
-      {
-        title: 'Failed Queries',
-        queries: [
-          {
-            query:
-              'increase(tidb_server_execute_error_total[$__rate_interval])',
-            name: '{type} @ {instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'short',
-        type: 'line'
-      },
-      {
-        title: 'Command Per Second',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_query_total[$__rate_interval])) by (type)',
-            name: '{type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'short',
-        type: 'line'
-      },
-      {
-        title: 'Queries Using Plan Cache OPS',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_plan_cache_total[$__rate_interval])) by (type)',
-            name: 'avg - hit'
-          },
-          {
-            query:
-              'sum(rate(tidb_server_plan_cache_miss_total[$__rate_interval]))',
-            name: 'avg - miss'
-          }
-        ],
-        unit: 'short',
-        nullValue: TransformNullValue.AS_ZERO,
-        type: 'line'
-      }
-    ]
-  },
-  {
-    category: 'latency_break_down',
-    metrics: [
-      {
-        title: 'Query Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) / sum(rate(tidb_server_handle_query_duration_seconds_count{sql_type!="internal"}[$__rate_interval]))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{sql_type!="internal"}[$__rate_interval])) by (le))',
-            name: '99'
-          },
-          {
-            query:
-              'sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) by (sql_type) / sum(rate(tidb_server_handle_query_duration_seconds_count{sql_type!="internal"}[$__rate_interval])) by (sql_type)',
-            name: 'avg-{sql_type}'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{sql_type!="internal"}[$__rate_interval])) by (le,sql_type))',
-            name: '99-{sql_type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average Idle Connection Duration',
-        queries: [
-          {
-            query: `(sum(rate(tidb_server_conn_idle_duration_seconds_sum{in_txn='1'}[$__rate_interval])) / sum(rate(tidb_server_conn_idle_duration_seconds_count{in_txn='1'}[$__rate_interval])))`,
-            name: 'avg-in-txn'
-          },
-          {
-            query: `(sum(rate(tidb_server_conn_idle_duration_seconds_sum{in_txn='0'}[$__rate_interval])) / sum(rate(tidb_server_conn_idle_duration_seconds_count{in_txn='0'}[$__rate_interval])))`,
-            name: 'avg-not-in-txn'
-          }
-        ],
-        unit: 's',
-        nullValue: TransformNullValue.AS_ZERO,
-        type: 'line'
-      },
-      {
-        title: 'Get Token Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_get_token_duration_seconds_sum[$__rate_interval])) / sum(rate(tidb_server_get_token_duration_seconds_count[$__rate_interval]))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_server_get_token_duration_seconds_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'µs',
-        type: 'line'
-      },
-      {
-        title: 'Parse Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tidb_session_parse_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_parse_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_session_parse_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Compile Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tidb_session_compile_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_compile_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_session_compile_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Execute Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tidb_session_execute_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_execute_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_session_execute_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      }
-    ]
-  },
-  {
-    category: 'transaction',
-    metrics: [
-      {
-        title: 'Transaction Per Second',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_session_transaction_duration_seconds_count[$__rate_interval])) by (type, txn_mode)',
-            name: '{type}-{txn_mode}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'short',
-        type: 'line'
-      },
-      {
-        title: 'Transaction Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_session_transaction_duration_seconds_sum[$__rate_interval])) by (txn_mode)/ sum(rate(tidb_session_transaction_duration_seconds_count[$__rate_interval])) by (txn_mode)',
-            name: 'avg-{txn_mode}'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_session_transaction_duration_seconds_bucket[$__rate_interval])) by (le, txn_mode))',
-            name: '99-{txn_mode}'
-          }
-        ],
-        unit: 's',
-        type: 'line'
-      }
-    ]
-  },
-  {
-    category: 'core_path_duration',
-    metrics: [
-      {
-        title: 'Avg TiDB KV Request Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_tikvclient_request_seconds_sum{store!="0"}[$__rate_interval])) by (type)/ sum(rate(tidb_tikvclient_request_seconds_count{store!="0"}[$__rate_interval])) by (type)',
-            name: '{type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Avg TiKV GRPC Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_grpc_msg_duration_seconds_sum{store!="0"}[$__rate_interval])) by (type)/ sum(rate(tikv_grpc_msg_duration_seconds_count{store!="0"}[$__rate_interval])) by (type)',
-            name: '{type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 PD TSO Wait/RPC Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(pd_client_cmd_handle_cmds_duration_seconds_sum{type="wait"}[$__rate_interval])) / sum(rate(pd_client_cmd_handle_cmds_duration_seconds_count{type="wait"}[$__rate_interval])))',
-            name: 'wait - avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(pd_client_cmd_handle_cmds_duration_seconds_bucket{type="wait"}[$__rate_interval])) by (le))',
-            name: 'wait - 99'
-          },
-          {
-            query:
-              '(sum(rate(pd_client_request_handle_requests_duration_seconds_sum{type="tso"}[$__rate_interval])) / sum(rate(pd_client_request_handle_requests_duration_seconds_count{type="tso"}[$__rate_interval])))',
-            name: 'rpc - avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(pd_client_request_handle_requests_duration_seconds_bucket{type="tso"}[$__rate_interval])) by (le))',
-            name: 'rpc - 99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Storage Async Write Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_storage_engine_async_request_duration_seconds_sum{type="write"}[$__rate_interval])) / sum(rate(tikv_storage_engine_async_request_duration_seconds_count{type="write"}[$__rate_interval]))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_storage_engine_async_request_duration_seconds_bucket{type="write"}[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Store Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_raftstore_store_duration_secs_sum[$__rate_interval])) / sum(rate(tikv_raftstore_store_duration_secs_count[$__rate_interval]))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_store_duration_secs_bucket[$__rate_interval])) by (le))',
-            name: ''
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Apply Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tikv_raftstore_apply_duration_secs_sum[$__rate_interval])) / sum(rate(tikv_raftstore_apply_duration_secs_count[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_apply_duration_secs_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Append Log Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tikv_raftstore_append_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_append_log_duration_seconds_count[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_append_log_duration_seconds_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Commit Log Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tikv_raftstore_commit_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_commit_log_duration_seconds_count[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_commit_log_duration_seconds_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Apply Log Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tikv_raftstore_apply_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_apply_log_duration_seconds_count[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_apply_log_duration_seconds_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      }
-    ]
-  },
-  {
-    category: 'server',
-    metrics: [
-      {
-        title: 'TiDB Uptime',
-        queries: [
-          {
-            query: '(time() - process_start_time_seconds{job="tidb"})',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'TiDB CPU Usage',
-        queries: [
-          {
-            query: 'rate(process_cpu_seconds_total{job="tidb"}[30s])',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'percentunit',
-        type: 'line'
-      },
-      {
-        title: 'TiDB Memory Usage',
-        queries: [
-          {
-            query: 'process_resident_memory_bytes{job="tidb"}',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'bytes',
-        type: 'line'
-      },
-      {
-        title: 'TiKV Uptime',
-        queries: [
-          {
-            query: '(time() - process_start_time_seconds{job="tikv"})',
-            name: '{instance}'
-          }
-        ],
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'TiKV CPU Usage',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_thread_cpu_seconds_total[$__rate_interval])) by (instance)',
-            name: '{instance}'
-          }
-        ],
-        unit: 'percentunit',
-        type: 'line'
-      },
-      {
-        title: 'TiKV Memory Usage',
-        queries: [
-          {
-            query: 'process_resident_memory_bytes{job=~".*tikv"}',
-            name: '{instance}'
-          }
-        ],
-        unit: 'bytes',
-        type: 'line'
-      },
-      {
-        title: 'TiKV IO MBps',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_engine_flow_bytes{db="kv", type="wal_file_bytes"}[$__rate_interval])) by (instance) + sum(rate(tikv_engine_flow_bytes{db="raft", type="wal_file_bytes"}[$__rate_interval])) by (instance) + sum(rate(raft_engine_write_size_sum[$__rate_interval])) by (instance)',
-            name: '{instance}-write'
-          },
-          {
-            query:
-              'sum(rate(tikv_engine_flow_bytes{db="kv", type=~"bytes_read|iter_bytes_read"}[$__rate_interval])) by (instance)',
-            name: '{instance}-read'
-          }
-        ],
-        unit: 'Bps',
-        type: 'line'
-      },
-      {
-        title: 'TiKV Storage Usage',
-        queries: [
-          {
-            query: 'sum(tikv_store_size_bytes{type="used"}) by (instance)',
-            name: '{instance}'
-          }
-        ],
-        unit: 'decbytes',
-        type: 'area_stack'
-      }
-    ]
-  }
-]
+const getMonitoringItems = (
+  pdVersion: string | undefined
+): MetricsQueryType[] => {
+  function loadTiKVStoragePromql() {
+    const PDVersion = pdVersion?.replace('v', '')
+    console.log('PDVersion', PDVersion)
 
-export { monitoringItems }
+    if (PDVersion && PDVersion < '5.4.1') {
+      return 'sum(tikv_engine_size_bytes) by (instance)'
+    }
+    return 'sum(tikv_store_size_bytes{type="used"}) by (instance)'
+  }
+
+  const monitoringItems: MetricsQueryType[] = [
+    {
+      category: 'database_time',
+      metrics: [
+        {
+          title: 'Database Time by SQL Types',
+          queries: [
+            {
+              query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval]))`,
+              name: 'database time',
+              color: ColorType.YELLOW,
+              type: 'line'
+            },
+            {
+              query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) by (sql_type)`,
+              name: '{sql_type}',
+              color: (qd: QueryData) => transformColorBySQLType(qd.name),
+              type: 'bar_stacked'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'mixed'
+        },
+        {
+          title: 'Database Time by SQL Phase',
+          queries: [
+            {
+              query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval]))`,
+              name: 'database time',
+              color: ColorType.YELLOW,
+              type: 'line'
+            },
+            {
+              query: `sum(rate(tidb_session_parse_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
+              name: 'parse',
+              color: ColorType.RED_2,
+              type: 'bar_stacked'
+            },
+            {
+              query: `sum(rate(tidb_session_compile_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
+              name: 'compile',
+              color: ColorType.ORANGE,
+              type: 'bar_stacked'
+            },
+            {
+              query: `sum(rate(tidb_session_execute_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
+              name: 'execute',
+              color: ColorType.GREEN_3,
+              type: 'bar_stacked'
+            },
+            {
+              query: `sum(rate(tidb_server_get_token_duration_seconds_sum[$__rate_interval]))/1000000`,
+              name: 'get token',
+              color: ColorType.RED_3,
+              type: 'bar_stacked'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'mixed'
+        },
+        {
+          title: 'SQL Execute Time Overview',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_tikvclient_request_seconds_sum{store!="0"}[$__rate_interval])) by (type)',
+              name: '{type}',
+              color: (qd: QueryData) =>
+                transformColorByExecTimeOverview(qd.name)
+            },
+            {
+              query:
+                'sum(rate(pd_client_cmd_handle_cmds_duration_seconds_sum{type="wait"}[$__rate_interval]))',
+              name: 'tso_wait',
+              color: ColorType.RED_5
+            }
+          ],
+          unit: 's',
+          type: 'bar_stacked'
+        }
+      ]
+    },
+    {
+      category: 'application_connection',
+      metrics: [
+        {
+          title: 'Connection Count',
+          queries: [
+            {
+              query: 'sum(tidb_server_connections)',
+              name: 'Total'
+            },
+            {
+              query: 'sum(tidb_server_tokens)',
+              name: 'active connections'
+            }
+          ],
+          unit: 'short',
+          nullValue: TransformNullValue.AS_ZERO,
+          type: 'line'
+        },
+        {
+          title: 'Disconnection',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_disconnection_total[$__rate_interval])) by (instance, result)',
+              name: '{instance}-{result}'
+            }
+          ],
+          unit: 'short',
+          nullValue: TransformNullValue.AS_ZERO,
+          type: 'area_stack'
+        }
+      ]
+    },
+    {
+      category: 'sql_count',
+      metrics: [
+        {
+          title: 'Query Per Second',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_executor_statement_total[$__rate_interval]))',
+              name: 'Total'
+            },
+            {
+              query:
+                'sum(rate(tidb_executor_statement_total[$__rate_interval])) by (type)',
+              name: '{type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'qps',
+          type: 'line'
+        },
+        {
+          title: 'Failed Queries',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_execute_error_total[$__rate_interval]))',
+              name: '{type} @ {instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'short',
+          type: 'line'
+        },
+        {
+          title: 'Command Per Second',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_query_total[$__rate_interval])) by (type)',
+              name: '{type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'short',
+          type: 'line'
+        },
+        {
+          title: 'Queries Using Plan Cache OPS',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_plan_cache_total[$__rate_interval]))',
+              name: 'avg - hit'
+            },
+            {
+              query:
+                'sum(rate(tidb_server_plan_cache_miss_total[$__rate_interval]))',
+              name: 'avg - miss'
+            }
+          ],
+          unit: 'short',
+          nullValue: TransformNullValue.AS_ZERO,
+          type: 'line'
+        }
+      ]
+    },
+    {
+      category: 'latency_break_down',
+      metrics: [
+        {
+          title: 'Query Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) / sum(rate(tidb_server_handle_query_duration_seconds_count{sql_type!="internal"}[$__rate_interval]))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{sql_type!="internal"}[$__rate_interval])) by (le))',
+              name: '99'
+            },
+            {
+              query:
+                'sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) by (sql_type) / sum(rate(tidb_server_handle_query_duration_seconds_count{sql_type!="internal"}[$__rate_interval])) by (sql_type)',
+              name: 'avg-{sql_type}'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket[$__rate_interval])) by (le,sql_type))',
+              name: '99-{sql_type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average Idle Connection Duration',
+          queries: [
+            {
+              query: `(sum(rate(tidb_server_conn_idle_duration_seconds_sum{in_txn='1'}[$__rate_interval])) / sum(rate(tidb_server_conn_idle_duration_seconds_count{in_txn='1'}[$__rate_interval])))`,
+              name: 'avg-in-txn'
+            },
+            {
+              query: `(sum(rate(tidb_server_conn_idle_duration_seconds_sum{in_txn='0'}[$__rate_interval])) / sum(rate(tidb_server_conn_idle_duration_seconds_count{in_txn='0'}[$__rate_interval])))`,
+              name: 'avg-not-in-txn'
+            }
+          ],
+          unit: 's',
+          nullValue: TransformNullValue.AS_ZERO,
+          type: 'line'
+        },
+        {
+          title: 'Get Token Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_get_token_duration_seconds_sum[$__rate_interval])) / sum(rate(tidb_server_get_token_duration_seconds_count[$__rate_interval]))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_server_get_token_duration_seconds_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'µs',
+          type: 'line'
+        },
+        {
+          title: 'Parse Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tidb_session_parse_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_parse_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_session_parse_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Compile Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tidb_session_compile_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_compile_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_session_compile_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Execute Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tidb_session_execute_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_execute_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_session_execute_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        }
+      ]
+    },
+    {
+      category: 'transaction',
+      metrics: [
+        {
+          title: 'Transaction Per Second',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_session_transaction_duration_seconds_count[$__rate_interval])) by (type, txn_mode)',
+              name: '{type}-{txn_mode}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'short',
+          type: 'line'
+        },
+        {
+          title: 'Transaction Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_session_transaction_duration_seconds_sum[$__rate_interval])) by (txn_mode)/ sum(rate(tidb_session_transaction_duration_seconds_count[$__rate_interval])) by (txn_mode)',
+              name: 'avg-{txn_mode}'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_session_transaction_duration_seconds_bucket[$__rate_interval])) by (le, txn_mode))',
+              name: '99-{txn_mode}'
+            }
+          ],
+          unit: 's',
+          type: 'line'
+        }
+      ]
+    },
+    {
+      category: 'core_path_duration',
+      metrics: [
+        {
+          title: 'Avg TiDB KV Request Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_tikvclient_request_seconds_sum{store!="0"}[$__rate_interval])) by (type)/ sum(rate(tidb_tikvclient_request_seconds_count{store!="0"}[$__rate_interval])) by (type)',
+              name: '{type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Avg TiKV GRPC Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_grpc_msg_duration_seconds_sum{store!="0"}[$__rate_interval])) by (type)/ sum(rate(tikv_grpc_msg_duration_seconds_count{store!="0"}[$__rate_interval])) by (type)',
+              name: '{type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 PD TSO Wait/RPC Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(pd_client_cmd_handle_cmds_duration_seconds_sum{type="wait"}[$__rate_interval])) / sum(rate(pd_client_cmd_handle_cmds_duration_seconds_count{type="wait"}[$__rate_interval])))',
+              name: 'wait - avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(pd_client_cmd_handle_cmds_duration_seconds_bucket{type="wait"}[$__rate_interval])) by (le))',
+              name: 'wait - 99'
+            },
+            {
+              query:
+                '(sum(rate(pd_client_request_handle_requests_duration_seconds_sum{type="tso"}[$__rate_interval])) / sum(rate(pd_client_request_handle_requests_duration_seconds_count{type="tso"}[$__rate_interval])))',
+              name: 'rpc - avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(pd_client_request_handle_requests_duration_seconds_bucket{type="tso"}[$__rate_interval])) by (le))',
+              name: 'rpc - 99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Storage Async Write Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_storage_engine_async_request_duration_seconds_sum{type="write"}[$__rate_interval])) / sum(rate(tikv_storage_engine_async_request_duration_seconds_count{type="write"}[$__rate_interval]))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_storage_engine_async_request_duration_seconds_bucket{type="write"}[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Store Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_raftstore_store_duration_secs_sum[$__rate_interval])) / sum(rate(tikv_raftstore_store_duration_secs_count[$__rate_interval]))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_store_duration_secs_bucket[$__rate_interval])) by (le))',
+              name: ''
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Apply Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tikv_raftstore_apply_duration_secs_sum[$__rate_interval])) / sum(rate(tikv_raftstore_apply_duration_secs_count[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_apply_duration_secs_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Append Log Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tikv_raftstore_append_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_append_log_duration_seconds_count[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_append_log_duration_seconds_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Commit Log Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tikv_raftstore_commit_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_commit_log_duration_seconds_count[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_commit_log_duration_seconds_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Apply Log Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tikv_raftstore_apply_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_apply_log_duration_seconds_count[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_apply_log_duration_seconds_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        }
+      ]
+    },
+    {
+      category: 'server',
+      metrics: [
+        {
+          title: 'TiDB Uptime',
+          queries: [
+            {
+              query: '(time() - process_start_time_seconds{component="tidb"})',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'TiDB CPU Usage',
+          queries: [
+            {
+              query:
+                'irate(process_cpu_seconds_total{component="tidb"}[$__rate_interval])',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'percentunit',
+          type: 'line'
+        },
+        {
+          title: 'TiDB Memory Usage',
+          queries: [
+            {
+              query: 'process_resident_memory_bytes{component="tidb"}',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'bytes',
+          type: 'line'
+        },
+        {
+          title: 'TiKV Uptime',
+          queries: [
+            {
+              query: '(time() - process_start_time_seconds{component="tikv"})',
+              name: '{instance}'
+            }
+          ],
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'TiKV CPU Usage',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_thread_cpu_seconds_total[$__rate_interval])) by (instance)',
+              name: '{instance}'
+            }
+          ],
+          unit: 'percentunit',
+          type: 'line'
+        },
+        {
+          title: 'TiKV Memory Usage',
+          queries: [
+            {
+              query:
+                'avg(process_resident_memory_bytes{component="tikv"}) by (instance)',
+              name: '{instance}'
+            }
+          ],
+          unit: 'bytes',
+          type: 'line'
+        },
+        {
+          title: 'TiKV IO MBps',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_engine_flow_bytes{db="kv", type="wal_file_bytes"}[$__rate_interval])) by (instance) + (sum(rate(tikv_engine_flow_bytes{db="raft", type="wal_file_bytes"}[$__rate_interval])) by (instance) or (0 * sum(rate(raft_engine_write_size_sum[$__rate_interval])) by (instance))) + (sum(rate(raft_engine_write_size_sum[$__rate_interval])) by (instance) or (0 * sum(rate(tikv_engine_flow_bytes{db="raft", type="wal_file_bytes"}[$__rate_interval])) by (instance)))',
+              name: '{instance}-write'
+            },
+            {
+              query:
+                'sum(rate(tikv_engine_flow_bytes{db="kv", type=~"bytes_read|iter_bytes_read"}[$__rate_interval])) by (instance)',
+              name: '{instance}-read'
+            }
+          ],
+          unit: 'Bps',
+          type: 'line'
+        },
+        {
+          title: 'TiKV Storage Usage',
+          queries: [
+            {
+              query: loadTiKVStoragePromql(),
+              name: '{instance}'
+            }
+          ],
+          unit: 'bytes',
+          type: 'area_stack'
+        },
+        {
+          title: 'TiFlash Uptime',
+          queries: [
+            {
+              query: 'tiflash_system_asynchronous_metric_Uptime',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'TiFlash CPU Usage',
+          queries: [
+            {
+              query:
+                'rate(tiflash_proxy_process_cpu_seconds_total{component="tiflash"}[$__rate_interval])',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'percentunit',
+          type: 'line'
+        },
+        {
+          title: 'TiFlash Memory',
+          queries: [
+            {
+              query:
+                'tiflash_proxy_process_resident_memory_bytes{component="tiflash"}',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'bytes',
+          type: 'line'
+        },
+        {
+          title: 'TiFlash IO MBps',
+          queries: [
+            {
+              query:
+                'sum(rate(tiflash_system_profile_event_WriteBufferFromFileDescriptorWriteBytes[$__rate_interval])) by (instance) + sum(rate(tiflash_system_profile_event_PSMWriteBytes[$__rate_interval])) by (instance) + sum(rate(tiflash_system_profile_event_WriteBufferAIOWriteBytes[$__rate_interval])) by (instance)',
+              name: '{instance}-write'
+            },
+            {
+              query:
+                'sum(rate(tiflash_system_profile_event_ReadBufferFromFileDescriptorReadBytes[$__rate_interval])) by (instance) + sum(rate(tiflash_system_profile_event_PSMReadBytes[$__rate_interval])) by (instance) + sum(rate(tiflash_system_profile_event_ReadBufferAIOReadBytes[$__rate_interval])) by (instance)',
+              name: '{instance}-read'
+            }
+          ],
+          unit: 'Bps',
+          type: 'line'
+        },
+        {
+          title: 'TiFlash Storage Usage',
+          queries: [
+            {
+              query:
+                'sum(tiflash_system_current_metric_StoreSizeUsed) by (instance)',
+              name: '{instance}'
+            }
+          ],
+          unit: 'bytes',
+          type: 'area_stack'
+        }
+      ]
+    }
+  ]
+
+  return monitoringItems
+}
+
+export { getMonitoringItems }

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Monitoring/metricsQueries.ts
@@ -5,6 +5,8 @@ import {
   MetricsQueryType
 } from '@pingcap/tidb-dashboard-lib'
 
+import compareVersions from 'compare-versions'
+
 function transformColorBySQLType(legendLabel: string) {
   switch (legendLabel) {
     case 'Select':
@@ -53,9 +55,8 @@ const getMonitoringItems = (
 ): MetricsQueryType[] => {
   function loadTiKVStoragePromql() {
     const PDVersion = pdVersion?.replace('v', '')
-    console.log('PDVersion', PDVersion)
 
-    if (PDVersion && PDVersion < '5.4.1') {
+    if (PDVersion && compareVersions.compare(PDVersion, '5.4.1', '<')) {
       return 'sum(tikv_engine_size_bytes) by (instance)'
     }
     return 'sum(tikv_store_size_bytes{type="used"}) by (instance)'

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Monitoring/metricsQueries.ts
@@ -5,7 +5,7 @@ import {
   MetricsQueryType
 } from '@pingcap/tidb-dashboard-lib'
 
-import compareVersions from 'compare-versions'
+import { compare } from 'compare-versions'
 
 function transformColorBySQLType(legendLabel: string) {
   switch (legendLabel) {
@@ -56,7 +56,7 @@ const getMonitoringItems = (
   function loadTiKVStoragePromql() {
     const PDVersion = pdVersion?.replace('v', '')
 
-    if (PDVersion && compareVersions.compare(PDVersion, '5.4.1', '<')) {
+    if (PDVersion && PDVersion !== 'N/A' && compare(PDVersion, '5.4.1', '<')) {
       return 'sum(tikv_engine_size_bytes) by (instance)'
     }
     return 'sum(tikv_store_size_bytes{type="used"}) by (instance)'

--- a/ui/packages/tidb-dashboard-for-dbaas/package.json
+++ b/ui/packages/tidb-dashboard-for-dbaas/package.json
@@ -27,6 +27,7 @@
     "@pingcap/tidb-dashboard-lib": "workspace:^1.0.0",
     "antd": "^4.18.7",
     "axios": "^0.27.2",
+    "compare-versions": "^5.0.1",
     "i18next": "^21.6.11",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/ui/packages/tidb-dashboard-for-dbaas/package.json
+++ b/ui/packages/tidb-dashboard-for-dbaas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pingcap/tidb-dashboard-for-dbaas",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "main": "dist/main.js",
   "module": "dist/main.js",
   "files": [

--- a/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/context.ts
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/context.ts
@@ -6,7 +6,8 @@ import {
 
 import client from '~/client'
 
-import { monitoringItems } from './metricsQueries'
+import { getMonitoringItems } from './metricsQueries'
+
 class DataSource implements IMonitoringDataSource {
   metricsQueryGet(
     endTimeSec?: number,
@@ -43,7 +44,8 @@ const RECENT_SECONDS = [
 export const ctx: () => IMonitoringContext = () => ({
   ds,
   cfg: {
-    metricsQueries: monitoringItems,
+    getMetricsQueries: (pdVersion: string | undefined) =>
+      getMonitoringItems(pdVersion),
     promeAddrConfigurable: false,
     timeRangeSelector: {
       recent_seconds: RECENT_SECONDS,

--- a/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/metricsQueries.ts
@@ -55,7 +55,6 @@ const getMonitoringItems = (
 ): MetricsQueryType[] => {
   function loadTiKVStoragePromql() {
     const PDVersion = pdVersion?.replace('v', '')
-    console.log('PDVersion', PDVersion)
 
     if (PDVersion && compareVersions.compare(PDVersion, '5.4.1', '<')) {
       return 'sum(tikv_engine_size_bytes) by (instance)'

--- a/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/metricsQueries.ts
@@ -48,683 +48,702 @@ function transformColorByExecTimeOverview(legendLabel: string) {
   }
 }
 
-const monitoringItems: MetricsQueryType[] = [
-  {
-    category: 'database_time',
-    metrics: [
-      {
-        title: 'Database Time by SQL Types',
-        queries: [
-          {
-            query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval]))`,
-            name: 'database time',
-            color: ColorType.YELLOW,
-            type: 'line'
-          },
-          {
-            query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) by (sql_type)`,
-            name: '{sql_type}',
-            color: (qd: QueryData) => transformColorBySQLType(qd.name),
-            type: 'bar_stacked'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'mixed'
-      },
-      {
-        title: 'Database Time by SQL Phase',
-        queries: [
-          {
-            query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval]))`,
-            name: 'database time',
-            color: ColorType.YELLOW,
-            type: 'line'
-          },
-          {
-            query: `sum(rate(tidb_session_parse_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
-            name: 'parse',
-            color: ColorType.RED_2,
-            type: 'bar_stacked'
-          },
-          {
-            query: `sum(rate(tidb_session_compile_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
-            name: 'compile',
-            color: ColorType.ORANGE,
-            type: 'bar_stacked'
-          },
-          {
-            query: `sum(rate(tidb_session_execute_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
-            name: 'execute',
-            color: ColorType.GREEN_3,
-            type: 'bar_stacked'
-          },
-          {
-            query: `sum(rate(tidb_server_get_token_duration_seconds_sum[$__rate_interval]))/1000000`,
-            name: 'get token',
-            color: ColorType.RED_3,
-            type: 'bar_stacked'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'mixed'
-      },
-      {
-        title: 'SQL Execute Time Overview',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_tikvclient_request_seconds_sum{store!="0"}[$__rate_interval])) by (type)',
-            name: '{type}',
-            color: (qd: QueryData) => transformColorByExecTimeOverview(qd.name)
-          },
-          {
-            query:
-              'sum(rate(pd_client_cmd_handle_cmds_duration_seconds_sum{type="wait"}[$__rate_interval]))',
-            name: 'tso_wait',
-            color: ColorType.RED_5
-          }
-        ],
-        unit: 's',
-        type: 'bar_stacked'
-      }
-    ]
-  },
-  {
-    category: 'application_connection',
-    metrics: [
-      {
-        title: 'Connection Count',
-        queries: [
-          {
-            query: 'sum(tidb_server_connections)',
-            name: 'Total'
-          },
-          {
-            query: 'sum(tidb_server_tokens)',
-            name: 'active connections'
-          }
-        ],
-        unit: 'short',
-        nullValue: TransformNullValue.AS_ZERO,
-        type: 'line'
-      },
-      {
-        title: 'Disconnection',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_disconnection_total[$__rate_interval])) by (instance, result)',
-            name: '{instance}-{result}'
-          }
-        ],
-        unit: 'short',
-        nullValue: TransformNullValue.AS_ZERO,
-        type: 'area_stack'
-      }
-    ]
-  },
-  {
-    category: 'sql_count',
-    metrics: [
-      {
-        title: 'Query Per Second',
-        queries: [
-          {
-            query: 'sum(rate(tidb_executor_statement_total[$__rate_interval]))',
-            name: 'Total'
-          },
-          {
-            query:
-              'sum(rate(tidb_executor_statement_total[$__rate_interval])) by (type)',
-            name: '{type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'qps',
-        type: 'line'
-      },
-      {
-        title: 'Failed Queries',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_execute_error_total[$__rate_interval]))',
-            name: '{type} @ {instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'short',
-        type: 'line'
-      },
-      {
-        title: 'Command Per Second',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_query_total[$__rate_interval])) by (type)',
-            name: '{type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'short',
-        type: 'line'
-      },
-      {
-        title: 'Queries Using Plan Cache OPS',
-        queries: [
-          {
-            query: 'sum(rate(tidb_server_plan_cache_total[$__rate_interval]))',
-            name: 'avg - hit'
-          },
-          {
-            query:
-              'sum(rate(tidb_server_plan_cache_miss_total[$__rate_interval]))',
-            name: 'avg - miss'
-          }
-        ],
-        unit: 'short',
-        nullValue: TransformNullValue.AS_ZERO,
-        type: 'line'
-      }
-    ]
-  },
-  {
-    category: 'latency_break_down',
-    metrics: [
-      {
-        title: 'Query Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) / sum(rate(tidb_server_handle_query_duration_seconds_count{sql_type!="internal"}[$__rate_interval]))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{sql_type!="internal"}[$__rate_interval])) by (le))',
-            name: '99'
-          },
-          {
-            query:
-              'sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) by (sql_type) / sum(rate(tidb_server_handle_query_duration_seconds_count{sql_type!="internal"}[$__rate_interval])) by (sql_type)',
-            name: 'avg-{sql_type}'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket[$__rate_interval])) by (le,sql_type))',
-            name: '99-{sql_type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average Idle Connection Duration',
-        queries: [
-          {
-            query: `(sum(rate(tidb_server_conn_idle_duration_seconds_sum{in_txn='1'}[$__rate_interval])) / sum(rate(tidb_server_conn_idle_duration_seconds_count{in_txn='1'}[$__rate_interval])))`,
-            name: 'avg-in-txn'
-          },
-          {
-            query: `(sum(rate(tidb_server_conn_idle_duration_seconds_sum{in_txn='0'}[$__rate_interval])) / sum(rate(tidb_server_conn_idle_duration_seconds_count{in_txn='0'}[$__rate_interval])))`,
-            name: 'avg-not-in-txn'
-          }
-        ],
-        unit: 's',
-        nullValue: TransformNullValue.AS_ZERO,
-        type: 'line'
-      },
-      {
-        title: 'Get Token Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_get_token_duration_seconds_sum[$__rate_interval])) / sum(rate(tidb_server_get_token_duration_seconds_count[$__rate_interval]))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_server_get_token_duration_seconds_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'µs',
-        type: 'line'
-      },
-      {
-        title: 'Parse Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tidb_session_parse_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_parse_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_session_parse_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Compile Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tidb_session_compile_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_compile_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_session_compile_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Execute Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tidb_session_execute_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_execute_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_session_execute_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      }
-    ]
-  },
-  {
-    category: 'transaction',
-    metrics: [
-      {
-        title: 'Transaction Per Second',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_session_transaction_duration_seconds_count[$__rate_interval])) by (type, txn_mode)',
-            name: '{type}-{txn_mode}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'short',
-        type: 'line'
-      },
-      {
-        title: 'Transaction Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_session_transaction_duration_seconds_sum[$__rate_interval])) by (txn_mode)/ sum(rate(tidb_session_transaction_duration_seconds_count[$__rate_interval])) by (txn_mode)',
-            name: 'avg-{txn_mode}'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_session_transaction_duration_seconds_bucket[$__rate_interval])) by (le, txn_mode))',
-            name: '99-{txn_mode}'
-          }
-        ],
-        unit: 's',
-        type: 'line'
-      }
-    ]
-  },
-  {
-    category: 'core_path_duration',
-    metrics: [
-      {
-        title: 'Avg TiDB KV Request Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_tikvclient_request_seconds_sum{store!="0"}[$__rate_interval])) by (type)/ sum(rate(tidb_tikvclient_request_seconds_count{store!="0"}[$__rate_interval])) by (type)',
-            name: '{type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Avg TiKV GRPC Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_grpc_msg_duration_seconds_sum{store!="0"}[$__rate_interval])) by (type)/ sum(rate(tikv_grpc_msg_duration_seconds_count{store!="0"}[$__rate_interval])) by (type)',
-            name: '{type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 PD TSO Wait/RPC Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(pd_client_cmd_handle_cmds_duration_seconds_sum{type="wait"}[$__rate_interval])) / sum(rate(pd_client_cmd_handle_cmds_duration_seconds_count{type="wait"}[$__rate_interval])))',
-            name: 'wait - avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(pd_client_cmd_handle_cmds_duration_seconds_bucket{type="wait"}[$__rate_interval])) by (le))',
-            name: 'wait - 99'
-          },
-          {
-            query:
-              '(sum(rate(pd_client_request_handle_requests_duration_seconds_sum{type="tso"}[$__rate_interval])) / sum(rate(pd_client_request_handle_requests_duration_seconds_count{type="tso"}[$__rate_interval])))',
-            name: 'rpc - avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(pd_client_request_handle_requests_duration_seconds_bucket{type="tso"}[$__rate_interval])) by (le))',
-            name: 'rpc - 99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Storage Async Write Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_storage_engine_async_request_duration_seconds_sum{type="write"}[$__rate_interval])) / sum(rate(tikv_storage_engine_async_request_duration_seconds_count{type="write"}[$__rate_interval]))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_storage_engine_async_request_duration_seconds_bucket{type="write"}[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Store Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_raftstore_store_duration_secs_sum[$__rate_interval])) / sum(rate(tikv_raftstore_store_duration_secs_count[$__rate_interval]))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_store_duration_secs_bucket[$__rate_interval])) by (le))',
-            name: ''
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Apply Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tikv_raftstore_apply_duration_secs_sum[$__rate_interval])) / sum(rate(tikv_raftstore_apply_duration_secs_count[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_apply_duration_secs_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Append Log Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tikv_raftstore_append_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_append_log_duration_seconds_count[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_append_log_duration_seconds_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Commit Log Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tikv_raftstore_commit_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_commit_log_duration_seconds_count[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_commit_log_duration_seconds_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Apply Log Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tikv_raftstore_apply_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_apply_log_duration_seconds_count[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_apply_log_duration_seconds_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      }
-    ]
-  },
-  {
-    category: 'server',
-    metrics: [
-      {
-        title: 'TiDB Uptime',
-        queries: [
-          {
-            query: '(time() - process_start_time_seconds{component="tidb"})',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'TiDB CPU Usage',
-        queries: [
-          {
-            query:
-              'irate(process_cpu_seconds_total{component="tidb"}[$__rate_interval])',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'percentunit',
-        type: 'line'
-      },
-      {
-        title: 'TiDB Memory Usage',
-        queries: [
-          {
-            query: 'process_resident_memory_bytes{component="tidb"}',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'bytes',
-        type: 'line'
-      },
-      {
-        title: 'TiKV Uptime',
-        queries: [
-          {
-            query: '(time() - process_start_time_seconds{component="tikv"})',
-            name: '{instance}'
-          }
-        ],
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'TiKV CPU Usage',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_thread_cpu_seconds_total[$__rate_interval])) by (instance)',
-            name: '{instance}'
-          }
-        ],
-        unit: 'percentunit',
-        type: 'line'
-      },
-      {
-        title: 'TiKV Memory Usage',
-        queries: [
-          {
-            query:
-              'avg(process_resident_memory_bytes{component="tikv"}) by (instance)',
-            name: '{instance}'
-          }
-        ],
-        unit: 'bytes',
-        type: 'line'
-      },
-      {
-        title: 'TiKV IO MBps',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_engine_flow_bytes{db="kv", type="wal_file_bytes"}[$__rate_interval])) by (instance) + (sum(rate(tikv_engine_flow_bytes{db="raft", type="wal_file_bytes"}[$__rate_interval])) by (instance) or (0 * sum(rate(raft_engine_write_size_sum[$__rate_interval])) by (instance))) + (sum(rate(raft_engine_write_size_sum[$__rate_interval])) by (instance) or (0 * sum(rate(tikv_engine_flow_bytes{db="raft", type="wal_file_bytes"}[$__rate_interval])) by (instance)))',
-            name: '{instance}-write'
-          },
-          {
-            query:
-              'sum(rate(tikv_engine_flow_bytes{db="kv", type=~"bytes_read|iter_bytes_read"}[$__rate_interval])) by (instance)',
-            name: '{instance}-read'
-          }
-        ],
-        unit: 'Bps',
-        type: 'line'
-      },
-      {
-        title: 'TiKV Storage Usage',
-        queries: [
-          {
-            query: 'sum(tikv_store_size_bytes{type="used"}) by (instance)',
-            name: '{instance}'
-          }
-        ],
-        unit: 'bytes',
-        type: 'area_stack'
-      },
-      {
-        title: 'TiFlash Uptime',
-        queries: [
-          {
-            query: 'tiflash_system_asynchronous_metric_Uptime',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'TiFlash CPU Usage',
-        queries: [
-          {
-            query:
-              'rate(tiflash_proxy_process_cpu_seconds_total{component="tiflash"}[$__rate_interval])',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'percentunit',
-        type: 'line'
-      },
-      {
-        title: 'TiFlash Memory',
-        queries: [
-          {
-            query:
-              'tiflash_proxy_process_resident_memory_bytes{component="tiflash"}',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'bytes',
-        type: 'line'
-      },
-      {
-        title: 'TiFlash IO MBps',
-        queries: [
-          {
-            query:
-              'sum(rate(tiflash_system_profile_event_WriteBufferFromFileDescriptorWriteBytes[$__rate_interval])) + sum(rate(tiflash_system_profile_event_PSMWriteBytes[$__rate_interval])) + sum(rate(tiflash_system_profile_event_WriteBufferAIOWriteBytes[$__rate_interval]))',
-            name: '{instance}-write'
-          },
-          {
-            query:
-              'sum(rate(tiflash_system_profile_event_ReadBufferFromFileDescriptorReadBytes[$__rate_interval])) + sum(rate(tiflash_system_profile_event_PSMReadBytes[$__rate_interval])) + sum(rate(tiflash_system_profile_event_ReadBufferAIOReadBytes[$__rate_interval]))',
-            name: '{instance}-read'
-          }
-        ],
-        unit: 'Bps',
-        type: 'line'
-      },
-      {
-        title: 'TiFlash Storage Usage',
-        queries: [
-          {
-            query:
-              'sum(tiflash_system_current_metric_StoreSizeUsed) by (instance)',
-            name: '{instance}'
-          }
-        ],
-        unit: 'bytes',
-        type: 'area_stack'
-      }
-    ]
-  }
-]
+const getMonitoringItems = (
+  pdVersion: string | undefined
+): MetricsQueryType[] => {
+  function loadTiKVStoragePromql() {
+    const PDVersion = pdVersion?.replace('v', '')
+    console.log('PDVersion', PDVersion)
 
-export { monitoringItems }
+    if (PDVersion && PDVersion < '5.4.1') {
+      return 'sum(tikv_engine_size_bytes) by (instance)'
+    }
+    return 'sum(tikv_store_size_bytes{type="used"}) by (instance)'
+  }
+
+  const monitoringItems: MetricsQueryType[] = [
+    {
+      category: 'database_time',
+      metrics: [
+        {
+          title: 'Database Time by SQL Types',
+          queries: [
+            {
+              query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval]))`,
+              name: 'database time',
+              color: ColorType.YELLOW,
+              type: 'line'
+            },
+            {
+              query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) by (sql_type)`,
+              name: '{sql_type}',
+              color: (qd: QueryData) => transformColorBySQLType(qd.name),
+              type: 'bar_stacked'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'mixed'
+        },
+        {
+          title: 'Database Time by SQL Phase',
+          queries: [
+            {
+              query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval]))`,
+              name: 'database time',
+              color: ColorType.YELLOW,
+              type: 'line'
+            },
+            {
+              query: `sum(rate(tidb_session_parse_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
+              name: 'parse',
+              color: ColorType.RED_2,
+              type: 'bar_stacked'
+            },
+            {
+              query: `sum(rate(tidb_session_compile_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
+              name: 'compile',
+              color: ColorType.ORANGE,
+              type: 'bar_stacked'
+            },
+            {
+              query: `sum(rate(tidb_session_execute_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
+              name: 'execute',
+              color: ColorType.GREEN_3,
+              type: 'bar_stacked'
+            },
+            {
+              query: `sum(rate(tidb_server_get_token_duration_seconds_sum[$__rate_interval]))/1000000`,
+              name: 'get token',
+              color: ColorType.RED_3,
+              type: 'bar_stacked'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'mixed'
+        },
+        {
+          title: 'SQL Execute Time Overview',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_tikvclient_request_seconds_sum{store!="0"}[$__rate_interval])) by (type)',
+              name: '{type}',
+              color: (qd: QueryData) =>
+                transformColorByExecTimeOverview(qd.name)
+            },
+            {
+              query:
+                'sum(rate(pd_client_cmd_handle_cmds_duration_seconds_sum{type="wait"}[$__rate_interval]))',
+              name: 'tso_wait',
+              color: ColorType.RED_5
+            }
+          ],
+          unit: 's',
+          type: 'bar_stacked'
+        }
+      ]
+    },
+    {
+      category: 'application_connection',
+      metrics: [
+        {
+          title: 'Connection Count',
+          queries: [
+            {
+              query: 'sum(tidb_server_connections)',
+              name: 'Total'
+            },
+            {
+              query: 'sum(tidb_server_tokens)',
+              name: 'active connections'
+            }
+          ],
+          unit: 'short',
+          nullValue: TransformNullValue.AS_ZERO,
+          type: 'line'
+        },
+        {
+          title: 'Disconnection',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_disconnection_total[$__rate_interval])) by (instance, result)',
+              name: '{instance}-{result}'
+            }
+          ],
+          unit: 'short',
+          nullValue: TransformNullValue.AS_ZERO,
+          type: 'area_stack'
+        }
+      ]
+    },
+    {
+      category: 'sql_count',
+      metrics: [
+        {
+          title: 'Query Per Second',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_executor_statement_total[$__rate_interval]))',
+              name: 'Total'
+            },
+            {
+              query:
+                'sum(rate(tidb_executor_statement_total[$__rate_interval])) by (type)',
+              name: '{type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'qps',
+          type: 'line'
+        },
+        {
+          title: 'Failed Queries',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_execute_error_total[$__rate_interval]))',
+              name: '{type} @ {instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'short',
+          type: 'line'
+        },
+        {
+          title: 'Command Per Second',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_query_total[$__rate_interval])) by (type)',
+              name: '{type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'short',
+          type: 'line'
+        },
+        {
+          title: 'Queries Using Plan Cache OPS',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_plan_cache_total[$__rate_interval]))',
+              name: 'avg - hit'
+            },
+            {
+              query:
+                'sum(rate(tidb_server_plan_cache_miss_total[$__rate_interval]))',
+              name: 'avg - miss'
+            }
+          ],
+          unit: 'short',
+          nullValue: TransformNullValue.AS_ZERO,
+          type: 'line'
+        }
+      ]
+    },
+    {
+      category: 'latency_break_down',
+      metrics: [
+        {
+          title: 'Query Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) / sum(rate(tidb_server_handle_query_duration_seconds_count{sql_type!="internal"}[$__rate_interval]))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{sql_type!="internal"}[$__rate_interval])) by (le))',
+              name: '99'
+            },
+            {
+              query:
+                'sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) by (sql_type) / sum(rate(tidb_server_handle_query_duration_seconds_count{sql_type!="internal"}[$__rate_interval])) by (sql_type)',
+              name: 'avg-{sql_type}'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket[$__rate_interval])) by (le,sql_type))',
+              name: '99-{sql_type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average Idle Connection Duration',
+          queries: [
+            {
+              query: `(sum(rate(tidb_server_conn_idle_duration_seconds_sum{in_txn='1'}[$__rate_interval])) / sum(rate(tidb_server_conn_idle_duration_seconds_count{in_txn='1'}[$__rate_interval])))`,
+              name: 'avg-in-txn'
+            },
+            {
+              query: `(sum(rate(tidb_server_conn_idle_duration_seconds_sum{in_txn='0'}[$__rate_interval])) / sum(rate(tidb_server_conn_idle_duration_seconds_count{in_txn='0'}[$__rate_interval])))`,
+              name: 'avg-not-in-txn'
+            }
+          ],
+          unit: 's',
+          nullValue: TransformNullValue.AS_ZERO,
+          type: 'line'
+        },
+        {
+          title: 'Get Token Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_get_token_duration_seconds_sum[$__rate_interval])) / sum(rate(tidb_server_get_token_duration_seconds_count[$__rate_interval]))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_server_get_token_duration_seconds_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'µs',
+          type: 'line'
+        },
+        {
+          title: 'Parse Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tidb_session_parse_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_parse_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_session_parse_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Compile Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tidb_session_compile_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_compile_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_session_compile_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Execute Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tidb_session_execute_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_execute_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_session_execute_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        }
+      ]
+    },
+    {
+      category: 'transaction',
+      metrics: [
+        {
+          title: 'Transaction Per Second',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_session_transaction_duration_seconds_count[$__rate_interval])) by (type, txn_mode)',
+              name: '{type}-{txn_mode}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'short',
+          type: 'line'
+        },
+        {
+          title: 'Transaction Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_session_transaction_duration_seconds_sum[$__rate_interval])) by (txn_mode)/ sum(rate(tidb_session_transaction_duration_seconds_count[$__rate_interval])) by (txn_mode)',
+              name: 'avg-{txn_mode}'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_session_transaction_duration_seconds_bucket[$__rate_interval])) by (le, txn_mode))',
+              name: '99-{txn_mode}'
+            }
+          ],
+          unit: 's',
+          type: 'line'
+        }
+      ]
+    },
+    {
+      category: 'core_path_duration',
+      metrics: [
+        {
+          title: 'Avg TiDB KV Request Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_tikvclient_request_seconds_sum{store!="0"}[$__rate_interval])) by (type)/ sum(rate(tidb_tikvclient_request_seconds_count{store!="0"}[$__rate_interval])) by (type)',
+              name: '{type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Avg TiKV GRPC Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_grpc_msg_duration_seconds_sum{store!="0"}[$__rate_interval])) by (type)/ sum(rate(tikv_grpc_msg_duration_seconds_count{store!="0"}[$__rate_interval])) by (type)',
+              name: '{type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 PD TSO Wait/RPC Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(pd_client_cmd_handle_cmds_duration_seconds_sum{type="wait"}[$__rate_interval])) / sum(rate(pd_client_cmd_handle_cmds_duration_seconds_count{type="wait"}[$__rate_interval])))',
+              name: 'wait - avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(pd_client_cmd_handle_cmds_duration_seconds_bucket{type="wait"}[$__rate_interval])) by (le))',
+              name: 'wait - 99'
+            },
+            {
+              query:
+                '(sum(rate(pd_client_request_handle_requests_duration_seconds_sum{type="tso"}[$__rate_interval])) / sum(rate(pd_client_request_handle_requests_duration_seconds_count{type="tso"}[$__rate_interval])))',
+              name: 'rpc - avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(pd_client_request_handle_requests_duration_seconds_bucket{type="tso"}[$__rate_interval])) by (le))',
+              name: 'rpc - 99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Storage Async Write Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_storage_engine_async_request_duration_seconds_sum{type="write"}[$__rate_interval])) / sum(rate(tikv_storage_engine_async_request_duration_seconds_count{type="write"}[$__rate_interval]))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_storage_engine_async_request_duration_seconds_bucket{type="write"}[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Store Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_raftstore_store_duration_secs_sum[$__rate_interval])) / sum(rate(tikv_raftstore_store_duration_secs_count[$__rate_interval]))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_store_duration_secs_bucket[$__rate_interval])) by (le))',
+              name: ''
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Apply Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tikv_raftstore_apply_duration_secs_sum[$__rate_interval])) / sum(rate(tikv_raftstore_apply_duration_secs_count[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_apply_duration_secs_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Append Log Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tikv_raftstore_append_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_append_log_duration_seconds_count[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_append_log_duration_seconds_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Commit Log Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tikv_raftstore_commit_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_commit_log_duration_seconds_count[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_commit_log_duration_seconds_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Apply Log Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tikv_raftstore_apply_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_apply_log_duration_seconds_count[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_apply_log_duration_seconds_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        }
+      ]
+    },
+    {
+      category: 'server',
+      metrics: [
+        {
+          title: 'TiDB Uptime',
+          queries: [
+            {
+              query: '(time() - process_start_time_seconds{component="tidb"})',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'TiDB CPU Usage',
+          queries: [
+            {
+              query:
+                'irate(process_cpu_seconds_total{component="tidb"}[$__rate_interval])',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'percentunit',
+          type: 'line'
+        },
+        {
+          title: 'TiDB Memory Usage',
+          queries: [
+            {
+              query: 'process_resident_memory_bytes{component="tidb"}',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'bytes',
+          type: 'line'
+        },
+        {
+          title: 'TiKV Uptime',
+          queries: [
+            {
+              query: '(time() - process_start_time_seconds{component="tikv"})',
+              name: '{instance}'
+            }
+          ],
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'TiKV CPU Usage',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_thread_cpu_seconds_total[$__rate_interval])) by (instance)',
+              name: '{instance}'
+            }
+          ],
+          unit: 'percentunit',
+          type: 'line'
+        },
+        {
+          title: 'TiKV Memory Usage',
+          queries: [
+            {
+              query:
+                'avg(process_resident_memory_bytes{component="tikv"}) by (instance)',
+              name: '{instance}'
+            }
+          ],
+          unit: 'bytes',
+          type: 'line'
+        },
+        {
+          title: 'TiKV IO MBps',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_engine_flow_bytes{db="kv", type="wal_file_bytes"}[$__rate_interval])) by (instance) + (sum(rate(tikv_engine_flow_bytes{db="raft", type="wal_file_bytes"}[$__rate_interval])) by (instance) or (0 * sum(rate(raft_engine_write_size_sum[$__rate_interval])) by (instance))) + (sum(rate(raft_engine_write_size_sum[$__rate_interval])) by (instance) or (0 * sum(rate(tikv_engine_flow_bytes{db="raft", type="wal_file_bytes"}[$__rate_interval])) by (instance)))',
+              name: '{instance}-write'
+            },
+            {
+              query:
+                'sum(rate(tikv_engine_flow_bytes{db="kv", type=~"bytes_read|iter_bytes_read"}[$__rate_interval])) by (instance)',
+              name: '{instance}-read'
+            }
+          ],
+          unit: 'Bps',
+          type: 'line'
+        },
+        {
+          title: 'TiKV Storage Usage',
+          queries: [
+            {
+              query: loadTiKVStoragePromql(),
+              name: '{instance}'
+            }
+          ],
+          unit: 'bytes',
+          type: 'area_stack'
+        },
+        {
+          title: 'TiFlash Uptime',
+          queries: [
+            {
+              query: 'tiflash_system_asynchronous_metric_Uptime',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'TiFlash CPU Usage',
+          queries: [
+            {
+              query:
+                'rate(tiflash_proxy_process_cpu_seconds_total{component="tiflash"}[$__rate_interval])',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'percentunit',
+          type: 'line'
+        },
+        {
+          title: 'TiFlash Memory',
+          queries: [
+            {
+              query:
+                'tiflash_proxy_process_resident_memory_bytes{component="tiflash"}',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'bytes',
+          type: 'line'
+        },
+        {
+          title: 'TiFlash IO MBps',
+          queries: [
+            {
+              query:
+                'sum(rate(tiflash_system_profile_event_WriteBufferFromFileDescriptorWriteBytes[$__rate_interval])) by (instance) + sum(rate(tiflash_system_profile_event_PSMWriteBytes[$__rate_interval])) by (instance) + sum(rate(tiflash_system_profile_event_WriteBufferAIOWriteBytes[$__rate_interval])) by (instance)',
+              name: '{instance}-write'
+            },
+            {
+              query:
+                'sum(rate(tiflash_system_profile_event_ReadBufferFromFileDescriptorReadBytes[$__rate_interval])) by (instance) + sum(rate(tiflash_system_profile_event_PSMReadBytes[$__rate_interval])) by (instance) + sum(rate(tiflash_system_profile_event_ReadBufferAIOReadBytes[$__rate_interval])) by (instance)',
+              name: '{instance}-read'
+            }
+          ],
+          unit: 'Bps',
+          type: 'line'
+        },
+        {
+          title: 'TiFlash Storage Usage',
+          queries: [
+            {
+              query:
+                'sum(tiflash_system_current_metric_StoreSizeUsed) by (instance)',
+              name: '{instance}'
+            }
+          ],
+          unit: 'bytes',
+          type: 'area_stack'
+        }
+      ]
+    }
+  ]
+
+  return monitoringItems
+}
+
+export { getMonitoringItems }

--- a/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/metricsQueries.ts
@@ -5,6 +5,8 @@ import {
   MetricsQueryType
 } from '@pingcap/tidb-dashboard-lib'
 
+import compareVersions from 'compare-versions'
+
 function transformColorBySQLType(legendLabel: string) {
   switch (legendLabel) {
     case 'Select':
@@ -55,7 +57,7 @@ const getMonitoringItems = (
     const PDVersion = pdVersion?.replace('v', '')
     console.log('PDVersion', PDVersion)
 
-    if (PDVersion && PDVersion < '5.4.1') {
+    if (PDVersion && compareVersions.compare(PDVersion, '5.4.1', '<')) {
       return 'sum(tikv_engine_size_bytes) by (instance)'
     }
     return 'sum(tikv_store_size_bytes{type="used"}) by (instance)'

--- a/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/metricsQueries.ts
@@ -5,7 +5,7 @@ import {
   MetricsQueryType
 } from '@pingcap/tidb-dashboard-lib'
 
-import compareVersions from 'compare-versions'
+import { compare } from 'compare-versions'
 
 function transformColorBySQLType(legendLabel: string) {
   switch (legendLabel) {
@@ -56,7 +56,7 @@ const getMonitoringItems = (
   function loadTiKVStoragePromql() {
     const PDVersion = pdVersion?.replace('v', '')
 
-    if (PDVersion && compareVersions.compare(PDVersion, '5.4.1', '<')) {
+    if (PDVersion && PDVersion !== 'N/A' && compare(PDVersion, '5.4.1', '<')) {
       return 'sum(tikv_engine_size_bytes) by (instance)'
     }
     return 'sum(tikv_store_size_bytes{type="used"}) by (instance)'

--- a/ui/packages/tidb-dashboard-for-op/package.json
+++ b/ui/packages/tidb-dashboard-for-op/package.json
@@ -26,6 +26,7 @@
     "axios": "^0.27.2",
     "bulma": "^0.9.4",
     "classnames": "^2.3.1",
+    "compare-versions": "^5.0.1",
     "eventemitter2": "^6.4.5",
     "i18next": "^21.6.11",
     "nprogress": "^0.2.0",

--- a/ui/packages/tidb-dashboard-for-op/src/apps/Monitoring/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/Monitoring/context.ts
@@ -6,7 +6,7 @@ import {
 
 import client from '~/client'
 
-import { monitoringItems } from './metricsQueries'
+import { getMonitoringItems } from './metricsQueries'
 
 class DataSource implements IMonitoringDataSource {
   metricsQueryGet(
@@ -33,6 +33,7 @@ const ds = new DataSource()
 export const ctx: IMonitoringContext = {
   ds,
   cfg: {
-    metricsQueries: monitoringItems
+    getMetricsQueries: (pdVersion: string | undefined) =>
+      getMonitoringItems(pdVersion)
   }
 }

--- a/ui/packages/tidb-dashboard-for-op/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/Monitoring/metricsQueries.ts
@@ -48,681 +48,699 @@ function transformColorByExecTimeOverview(legendLabel: string) {
   }
 }
 
-const monitoringItems: MetricsQueryType[] = [
-  {
-    category: 'database_time',
-    metrics: [
-      {
-        title: 'Database Time by SQL Types',
-        queries: [
-          {
-            query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval]))`,
-            name: 'database time',
-            color: ColorType.YELLOW,
-            type: 'line'
-          },
-          {
-            query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) by (sql_type)`,
-            name: '{sql_type}',
-            color: (qd: QueryData) => transformColorBySQLType(qd.name),
-            type: 'bar_stacked'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'mixed'
-      },
-      {
-        title: 'Database Time by SQL Phase',
-        queries: [
-          {
-            query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval]))`,
-            name: 'database time',
-            color: ColorType.YELLOW,
-            type: 'line'
-          },
-          {
-            query: `sum(rate(tidb_session_parse_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
-            name: 'parse',
-            color: ColorType.RED_2,
-            type: 'bar_stacked'
-          },
-          {
-            query: `sum(rate(tidb_session_compile_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
-            name: 'compile',
-            color: ColorType.ORANGE,
-            type: 'bar_stacked'
-          },
-          {
-            query: `sum(rate(tidb_session_execute_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
-            name: 'execute',
-            color: ColorType.GREEN_3,
-            type: 'bar_stacked'
-          },
-          {
-            query: `sum(rate(tidb_server_get_token_duration_seconds_sum[$__rate_interval]))/1000000`,
-            name: 'get token',
-            color: ColorType.RED_3,
-            type: 'bar_stacked'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'mixed'
-      },
-      {
-        title: 'SQL Execute Time Overview',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_tikvclient_request_seconds_sum{store!="0"}[$__rate_interval])) by (type)',
-            name: '{type}',
-            color: (qd: QueryData) => transformColorByExecTimeOverview(qd.name)
-          },
-          {
-            query:
-              'sum(rate(pd_client_cmd_handle_cmds_duration_seconds_sum{type="wait"}[$__rate_interval]))',
-            name: 'tso_wait',
-            color: ColorType.RED_5
-          }
-        ],
-        unit: 's',
-        type: 'bar_stacked'
-      }
-    ]
-  },
-  {
-    category: 'application_connection',
-    metrics: [
-      {
-        title: 'Connection Count',
-        queries: [
-          {
-            query: 'sum(tidb_server_connections)',
-            name: 'Total'
-          },
-          {
-            query: 'sum(tidb_server_tokens)',
-            name: 'active connections'
-          }
-        ],
-        unit: 'short',
-        nullValue: TransformNullValue.AS_ZERO,
-        type: 'line'
-      },
-      {
-        title: 'Disconnection',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_disconnection_total[$__rate_interval])) by (instance, result)',
-            name: '{instance}-{result}'
-          }
-        ],
-        unit: 'short',
-        nullValue: TransformNullValue.AS_ZERO,
-        type: 'area_stack'
-      }
-    ]
-  },
-  {
-    category: 'sql_count',
-    metrics: [
-      {
-        title: 'Query Per Second',
-        queries: [
-          {
-            query: 'sum(rate(tidb_executor_statement_total[$__rate_interval]))',
-            name: 'Total'
-          },
-          {
-            query:
-              'sum(rate(tidb_executor_statement_total[$__rate_interval])) by (type)',
-            name: '{type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'qps',
-        type: 'line'
-      },
-      {
-        title: 'Failed Queries',
-        queries: [
-          {
-            query:
-              'increase(tidb_server_execute_error_total[$__rate_interval])',
-            name: '{type} @ {instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'short',
-        type: 'line'
-      },
-      {
-        title: 'Command Per Second',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_query_total[$__rate_interval])) by (type)',
-            name: '{type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'short',
-        type: 'line'
-      },
-      {
-        title: 'Queries Using Plan Cache OPS',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_plan_cache_total[$__rate_interval])) by (type)',
-            name: 'avg - hit'
-          },
-          {
-            query:
-              'sum(rate(tidb_server_plan_cache_miss_total[$__rate_interval]))',
-            name: 'avg - miss'
-          }
-        ],
-        unit: 'short',
-        nullValue: TransformNullValue.AS_ZERO,
-        type: 'line'
-      }
-    ]
-  },
-  {
-    category: 'latency_break_down',
-    metrics: [
-      {
-        title: 'Query Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) / sum(rate(tidb_server_handle_query_duration_seconds_count{sql_type!="internal"}[$__rate_interval]))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{sql_type!="internal"}[$__rate_interval])) by (le))',
-            name: '99'
-          },
-          {
-            query:
-              'sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) by (sql_type) / sum(rate(tidb_server_handle_query_duration_seconds_count{sql_type!="internal"}[$__rate_interval])) by (sql_type)',
-            name: 'avg-{sql_type}'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{sql_type!="internal"}[$__rate_interval])) by (le,sql_type))',
-            name: '99-{sql_type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average Idle Connection Duration',
-        queries: [
-          {
-            query: `(sum(rate(tidb_server_conn_idle_duration_seconds_sum{in_txn='1'}[$__rate_interval])) / sum(rate(tidb_server_conn_idle_duration_seconds_count{in_txn='1'}[$__rate_interval])))`,
-            name: 'avg-in-txn'
-          },
-          {
-            query: `(sum(rate(tidb_server_conn_idle_duration_seconds_sum{in_txn='0'}[$__rate_interval])) / sum(rate(tidb_server_conn_idle_duration_seconds_count{in_txn='0'}[$__rate_interval])))`,
-            name: 'avg-not-in-txn'
-          }
-        ],
-        unit: 's',
-        nullValue: TransformNullValue.AS_ZERO,
-        type: 'line'
-      },
-      {
-        title: 'Get Token Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_server_get_token_duration_seconds_sum[$__rate_interval])) / sum(rate(tidb_server_get_token_duration_seconds_count[$__rate_interval]))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_server_get_token_duration_seconds_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'µs',
-        type: 'line'
-      },
-      {
-        title: 'Parse Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tidb_session_parse_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_parse_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_session_parse_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Compile Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tidb_session_compile_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_compile_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_session_compile_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Execute Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tidb_session_execute_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_execute_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_session_execute_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      }
-    ]
-  },
-  {
-    category: 'transaction',
-    metrics: [
-      {
-        title: 'Transaction Per Second',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_session_transaction_duration_seconds_count[$__rate_interval])) by (type, txn_mode)',
-            name: '{type}-{txn_mode}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'short',
-        type: 'line'
-      },
-      {
-        title: 'Transaction Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_session_transaction_duration_seconds_sum[$__rate_interval])) by (txn_mode)/ sum(rate(tidb_session_transaction_duration_seconds_count[$__rate_interval])) by (txn_mode)',
-            name: 'avg-{txn_mode}'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tidb_session_transaction_duration_seconds_bucket[$__rate_interval])) by (le, txn_mode))',
-            name: '99-{txn_mode}'
-          }
-        ],
-        unit: 's',
-        type: 'line'
-      }
-    ]
-  },
-  {
-    category: 'core_path_duration',
-    metrics: [
-      {
-        title: 'Avg TiDB KV Request Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tidb_tikvclient_request_seconds_sum{store!="0"}[$__rate_interval])) by (type)/ sum(rate(tidb_tikvclient_request_seconds_count{store!="0"}[$__rate_interval])) by (type)',
-            name: '{type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Avg TiKV GRPC Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_grpc_msg_duration_seconds_sum{store!="0"}[$__rate_interval])) by (type)/ sum(rate(tikv_grpc_msg_duration_seconds_count{store!="0"}[$__rate_interval])) by (type)',
-            name: '{type}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 PD TSO Wait/RPC Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(pd_client_cmd_handle_cmds_duration_seconds_sum{type="wait"}[$__rate_interval])) / sum(rate(pd_client_cmd_handle_cmds_duration_seconds_count{type="wait"}[$__rate_interval])))',
-            name: 'wait - avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(pd_client_cmd_handle_cmds_duration_seconds_bucket{type="wait"}[$__rate_interval])) by (le))',
-            name: 'wait - 99'
-          },
-          {
-            query:
-              '(sum(rate(pd_client_request_handle_requests_duration_seconds_sum{type="tso"}[$__rate_interval])) / sum(rate(pd_client_request_handle_requests_duration_seconds_count{type="tso"}[$__rate_interval])))',
-            name: 'rpc - avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(pd_client_request_handle_requests_duration_seconds_bucket{type="tso"}[$__rate_interval])) by (le))',
-            name: 'rpc - 99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Storage Async Write Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_storage_engine_async_request_duration_seconds_sum{type="write"}[$__rate_interval])) / sum(rate(tikv_storage_engine_async_request_duration_seconds_count{type="write"}[$__rate_interval]))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_storage_engine_async_request_duration_seconds_bucket{type="write"}[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Store Duration',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_raftstore_store_duration_secs_sum[$__rate_interval])) / sum(rate(tikv_raftstore_store_duration_secs_count[$__rate_interval]))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_store_duration_secs_bucket[$__rate_interval])) by (le))',
-            name: ''
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Apply Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tikv_raftstore_apply_duration_secs_sum[$__rate_interval])) / sum(rate(tikv_raftstore_apply_duration_secs_count[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_apply_duration_secs_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Append Log Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tikv_raftstore_append_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_append_log_duration_seconds_count[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_append_log_duration_seconds_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Commit Log Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tikv_raftstore_commit_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_commit_log_duration_seconds_count[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_commit_log_duration_seconds_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'Average / P99 Apply Log Duration',
-        queries: [
-          {
-            query:
-              '(sum(rate(tikv_raftstore_apply_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_apply_log_duration_seconds_count[$__rate_interval])))',
-            name: 'avg'
-          },
-          {
-            query:
-              'histogram_quantile(0.99, sum(rate(tikv_raftstore_apply_log_duration_seconds_bucket[$__rate_interval])) by (le))',
-            name: '99'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      }
-    ]
-  },
-  {
-    category: 'server',
-    metrics: [
-      {
-        title: 'TiDB Uptime',
-        queries: [
-          {
-            query: '(time() - process_start_time_seconds{job="tidb"})',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'TiDB CPU Usage',
-        queries: [
-          {
-            query: 'rate(process_cpu_seconds_total{job="tidb"}[30s])',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'percentunit',
-        type: 'line'
-      },
-      {
-        title: 'TiDB Memory Usage',
-        queries: [
-          {
-            query: 'process_resident_memory_bytes{job="tidb"}',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'bytes',
-        type: 'line'
-      },
-      {
-        title: 'TiKV Uptime',
-        queries: [
-          {
-            query: '(time() - process_start_time_seconds{job="tikv"})',
-            name: '{instance}'
-          }
-        ],
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'TiKV CPU Usage',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_thread_cpu_seconds_total[$__rate_interval])) by (instance)',
-            name: '{instance}'
-          }
-        ],
-        unit: 'percentunit',
-        type: 'line'
-      },
-      {
-        title: 'TiKV Memory Usage',
-        queries: [
-          {
-            query: 'process_resident_memory_bytes{job=~".*tikv"}',
-            name: '{instance}'
-          }
-        ],
-        unit: 'bytes',
-        type: 'line'
-      },
-      {
-        title: 'TiKV IO MBps',
-        queries: [
-          {
-            query:
-              'sum(rate(tikv_engine_flow_bytes{db="kv", type="wal_file_bytes"}[$__rate_interval])) by (instance) + sum(rate(tikv_engine_flow_bytes{db="raft", type="wal_file_bytes"}[$__rate_interval])) by (instance) + sum(rate(raft_engine_write_size_sum[$__rate_interval])) by (instance)',
-            name: '{instance}-write'
-          },
-          {
-            query:
-              'sum(rate(tikv_engine_flow_bytes{db="kv", type=~"bytes_read|iter_bytes_read"}[$__rate_interval])) by (instance)',
-            name: '{instance}-read'
-          }
-        ],
-        unit: 'Bps',
-        type: 'line'
-      },
-      {
-        title: 'TiKV Storage Usage',
-        queries: [
-          {
-            query: 'sum(tikv_store_size_bytes{type="used"}) by (instance)',
-            name: '{instance}'
-          }
-        ],
-        unit: 'decbytes',
-        type: 'area_stack'
-      },
-      {
-        title: 'TiFlash Uptime',
-        queries: [
-          {
-            query: 'tiflash_system_asynchronous_metric_Uptime',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 's',
-        type: 'line'
-      },
-      {
-        title: 'TiFlash CPU Usage',
-        queries: [
-          {
-            query:
-              'rate(tiflash_proxy_process_cpu_seconds_total{job="tiflash"}[$__rate_interval])',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'percentunit',
-        type: 'line'
-      },
-      {
-        title: 'TiFlash Memory',
-        queries: [
-          {
-            query: 'tiflash_proxy_process_resident_memory_bytes{job="tiflash"}',
-            name: '{instance}'
-          }
-        ],
-        nullValue: TransformNullValue.AS_ZERO,
-        unit: 'bytes',
-        type: 'line'
-      },
-      {
-        title: 'TiFlash IO MBps',
-        queries: [
-          {
-            query:
-              'sum(rate(tiflash_system_profile_event_WriteBufferFromFileDescriptorWriteBytes[$__rate_interval])) + sum(rate(tiflash_system_profile_event_PSMWriteBytes[$__rate_interval])) + sum(rate(tiflash_system_profile_event_WriteBufferAIOWriteBytes[$__rate_interval]))',
-            name: '{instance}-write'
-          },
-          {
-            query:
-              'sum(rate(tiflash_system_profile_event_ReadBufferFromFileDescriptorReadBytes[$__rate_interval])) + sum(rate(tiflash_system_profile_event_PSMReadBytes[$__rate_interval])) + sum(rate(tiflash_system_profile_event_ReadBufferAIOReadBytes[$__rate_interval]))',
-            name: '{instance}-read'
-          }
-        ],
-        unit: 'Bps',
-        type: 'line'
-      },
-      {
-        title: 'TiFlash Storage Usage',
-        queries: [
-          {
-            query:
-              'sum(tiflash_system_current_metric_StoreSizeUsed) by (instance)',
-            name: '{instance}'
-          }
-        ],
-        unit: 'bytes',
-        type: 'area_stack'
-      }
-    ]
-  }
-]
+const getMonitoringItems = (
+  pdVersion: string | undefined
+): MetricsQueryType[] => {
+  function loadTiKVStoragePromql() {
+    const PDVersion = pdVersion?.replace('v', '')
 
-export { monitoringItems }
+    if (PDVersion && PDVersion < '5.4.1') {
+      return 'sum(tikv_engine_size_bytes) by (instance)'
+    }
+    return 'sum(tikv_store_size_bytes{type="used"}) by (instance)'
+  }
+
+  const monitoringItems: MetricsQueryType[] = [
+    {
+      category: 'database_time',
+      metrics: [
+        {
+          title: 'Database Time by SQL Types',
+          queries: [
+            {
+              query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval]))`,
+              name: 'database time',
+              color: ColorType.YELLOW,
+              type: 'line'
+            },
+            {
+              query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) by (sql_type)`,
+              name: '{sql_type}',
+              color: (qd: QueryData) => transformColorBySQLType(qd.name),
+              type: 'bar_stacked'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'mixed'
+        },
+        {
+          title: 'Database Time by SQL Phase',
+          queries: [
+            {
+              query: `sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval]))`,
+              name: 'database time',
+              color: ColorType.YELLOW,
+              type: 'line'
+            },
+            {
+              query: `sum(rate(tidb_session_parse_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
+              name: 'parse',
+              color: ColorType.RED_2,
+              type: 'bar_stacked'
+            },
+            {
+              query: `sum(rate(tidb_session_compile_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
+              name: 'compile',
+              color: ColorType.ORANGE,
+              type: 'bar_stacked'
+            },
+            {
+              query: `sum(rate(tidb_session_execute_duration_seconds_sum{sql_type="general"}[$__rate_interval]))`,
+              name: 'execute',
+              color: ColorType.GREEN_3,
+              type: 'bar_stacked'
+            },
+            {
+              query: `sum(rate(tidb_server_get_token_duration_seconds_sum[$__rate_interval]))/1000000`,
+              name: 'get token',
+              color: ColorType.RED_3,
+              type: 'bar_stacked'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'mixed'
+        },
+        {
+          title: 'SQL Execute Time Overview',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_tikvclient_request_seconds_sum{store!="0"}[$__rate_interval])) by (type)',
+              name: '{type}',
+              color: (qd: QueryData) =>
+                transformColorByExecTimeOverview(qd.name)
+            },
+            {
+              query:
+                'sum(rate(pd_client_cmd_handle_cmds_duration_seconds_sum{type="wait"}[$__rate_interval]))',
+              name: 'tso_wait',
+              color: ColorType.RED_5
+            }
+          ],
+          unit: 's',
+          type: 'bar_stacked'
+        }
+      ]
+    },
+    {
+      category: 'application_connection',
+      metrics: [
+        {
+          title: 'Connection Count',
+          queries: [
+            {
+              query: 'sum(tidb_server_connections)',
+              name: 'Total'
+            },
+            {
+              query: 'sum(tidb_server_tokens)',
+              name: 'active connections'
+            }
+          ],
+          unit: 'short',
+          nullValue: TransformNullValue.AS_ZERO,
+          type: 'line'
+        },
+        {
+          title: 'Disconnection',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_disconnection_total[$__rate_interval])) by (instance, result)',
+              name: '{instance}-{result}'
+            }
+          ],
+          unit: 'short',
+          nullValue: TransformNullValue.AS_ZERO,
+          type: 'area_stack'
+        }
+      ]
+    },
+    {
+      category: 'sql_count',
+      metrics: [
+        {
+          title: 'Query Per Second',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_executor_statement_total[$__rate_interval]))',
+              name: 'Total'
+            },
+            {
+              query:
+                'sum(rate(tidb_executor_statement_total[$__rate_interval])) by (type)',
+              name: '{type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'qps',
+          type: 'line'
+        },
+        {
+          title: 'Failed Queries',
+          queries: [
+            {
+              query:
+                'increase(tidb_server_execute_error_total[$__rate_interval])',
+              name: '{type} @ {instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'short',
+          type: 'line'
+        },
+        {
+          title: 'Command Per Second',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_query_total[$__rate_interval])) by (type)',
+              name: '{type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'short',
+          type: 'line'
+        },
+        {
+          title: 'Queries Using Plan Cache OPS',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_plan_cache_total[$__rate_interval])) by (type)',
+              name: 'avg - hit'
+            },
+            {
+              query:
+                'sum(rate(tidb_server_plan_cache_miss_total[$__rate_interval]))',
+              name: 'avg - miss'
+            }
+          ],
+          unit: 'short',
+          nullValue: TransformNullValue.AS_ZERO,
+          type: 'line'
+        }
+      ]
+    },
+    {
+      category: 'latency_break_down',
+      metrics: [
+        {
+          title: 'Query Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) / sum(rate(tidb_server_handle_query_duration_seconds_count{sql_type!="internal"}[$__rate_interval]))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{sql_type!="internal"}[$__rate_interval])) by (le))',
+              name: '99'
+            },
+            {
+              query:
+                'sum(rate(tidb_server_handle_query_duration_seconds_sum{sql_type!="internal"}[$__rate_interval])) by (sql_type) / sum(rate(tidb_server_handle_query_duration_seconds_count{sql_type!="internal"}[$__rate_interval])) by (sql_type)',
+              name: 'avg-{sql_type}'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_server_handle_query_duration_seconds_bucket{sql_type!="internal"}[$__rate_interval])) by (le,sql_type))',
+              name: '99-{sql_type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average Idle Connection Duration',
+          queries: [
+            {
+              query: `(sum(rate(tidb_server_conn_idle_duration_seconds_sum{in_txn='1'}[$__rate_interval])) / sum(rate(tidb_server_conn_idle_duration_seconds_count{in_txn='1'}[$__rate_interval])))`,
+              name: 'avg-in-txn'
+            },
+            {
+              query: `(sum(rate(tidb_server_conn_idle_duration_seconds_sum{in_txn='0'}[$__rate_interval])) / sum(rate(tidb_server_conn_idle_duration_seconds_count{in_txn='0'}[$__rate_interval])))`,
+              name: 'avg-not-in-txn'
+            }
+          ],
+          unit: 's',
+          nullValue: TransformNullValue.AS_ZERO,
+          type: 'line'
+        },
+        {
+          title: 'Get Token Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_server_get_token_duration_seconds_sum[$__rate_interval])) / sum(rate(tidb_server_get_token_duration_seconds_count[$__rate_interval]))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_server_get_token_duration_seconds_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'µs',
+          type: 'line'
+        },
+        {
+          title: 'Parse Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tidb_session_parse_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_parse_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_session_parse_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Compile Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tidb_session_compile_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_compile_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_session_compile_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Execute Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tidb_session_execute_duration_seconds_sum{sql_type="general"}[$__rate_interval])) / sum(rate(tidb_session_execute_duration_seconds_count{sql_type="general"}[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_session_execute_duration_seconds_bucket{sql_type="general"}[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        }
+      ]
+    },
+    {
+      category: 'transaction',
+      metrics: [
+        {
+          title: 'Transaction Per Second',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_session_transaction_duration_seconds_count[$__rate_interval])) by (type, txn_mode)',
+              name: '{type}-{txn_mode}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'short',
+          type: 'line'
+        },
+        {
+          title: 'Transaction Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_session_transaction_duration_seconds_sum[$__rate_interval])) by (txn_mode)/ sum(rate(tidb_session_transaction_duration_seconds_count[$__rate_interval])) by (txn_mode)',
+              name: 'avg-{txn_mode}'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tidb_session_transaction_duration_seconds_bucket[$__rate_interval])) by (le, txn_mode))',
+              name: '99-{txn_mode}'
+            }
+          ],
+          unit: 's',
+          type: 'line'
+        }
+      ]
+    },
+    {
+      category: 'core_path_duration',
+      metrics: [
+        {
+          title: 'Avg TiDB KV Request Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tidb_tikvclient_request_seconds_sum{store!="0"}[$__rate_interval])) by (type)/ sum(rate(tidb_tikvclient_request_seconds_count{store!="0"}[$__rate_interval])) by (type)',
+              name: '{type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Avg TiKV GRPC Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_grpc_msg_duration_seconds_sum{store!="0"}[$__rate_interval])) by (type)/ sum(rate(tikv_grpc_msg_duration_seconds_count{store!="0"}[$__rate_interval])) by (type)',
+              name: '{type}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 PD TSO Wait/RPC Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(pd_client_cmd_handle_cmds_duration_seconds_sum{type="wait"}[$__rate_interval])) / sum(rate(pd_client_cmd_handle_cmds_duration_seconds_count{type="wait"}[$__rate_interval])))',
+              name: 'wait - avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(pd_client_cmd_handle_cmds_duration_seconds_bucket{type="wait"}[$__rate_interval])) by (le))',
+              name: 'wait - 99'
+            },
+            {
+              query:
+                '(sum(rate(pd_client_request_handle_requests_duration_seconds_sum{type="tso"}[$__rate_interval])) / sum(rate(pd_client_request_handle_requests_duration_seconds_count{type="tso"}[$__rate_interval])))',
+              name: 'rpc - avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(pd_client_request_handle_requests_duration_seconds_bucket{type="tso"}[$__rate_interval])) by (le))',
+              name: 'rpc - 99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Storage Async Write Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_storage_engine_async_request_duration_seconds_sum{type="write"}[$__rate_interval])) / sum(rate(tikv_storage_engine_async_request_duration_seconds_count{type="write"}[$__rate_interval]))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_storage_engine_async_request_duration_seconds_bucket{type="write"}[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Store Duration',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_raftstore_store_duration_secs_sum[$__rate_interval])) / sum(rate(tikv_raftstore_store_duration_secs_count[$__rate_interval]))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_store_duration_secs_bucket[$__rate_interval])) by (le))',
+              name: ''
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Apply Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tikv_raftstore_apply_duration_secs_sum[$__rate_interval])) / sum(rate(tikv_raftstore_apply_duration_secs_count[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_apply_duration_secs_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Append Log Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tikv_raftstore_append_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_append_log_duration_seconds_count[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_append_log_duration_seconds_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Commit Log Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tikv_raftstore_commit_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_commit_log_duration_seconds_count[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_commit_log_duration_seconds_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'Average / P99 Apply Log Duration',
+          queries: [
+            {
+              query:
+                '(sum(rate(tikv_raftstore_apply_log_duration_seconds_sum[$__rate_interval])) / sum(rate(tikv_raftstore_apply_log_duration_seconds_count[$__rate_interval])))',
+              name: 'avg'
+            },
+            {
+              query:
+                'histogram_quantile(0.99, sum(rate(tikv_raftstore_apply_log_duration_seconds_bucket[$__rate_interval])) by (le))',
+              name: '99'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        }
+      ]
+    },
+    {
+      category: 'server',
+      metrics: [
+        {
+          title: 'TiDB Uptime',
+          queries: [
+            {
+              query: '(time() - process_start_time_seconds{job="tidb"})',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'TiDB CPU Usage',
+          queries: [
+            {
+              query: 'rate(process_cpu_seconds_total{job="tidb"}[30s])',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'percentunit',
+          type: 'line'
+        },
+        {
+          title: 'TiDB Memory Usage',
+          queries: [
+            {
+              query: 'process_resident_memory_bytes{job="tidb"}',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'bytes',
+          type: 'line'
+        },
+        {
+          title: 'TiKV Uptime',
+          queries: [
+            {
+              query: '(time() - process_start_time_seconds{job="tikv"})',
+              name: '{instance}'
+            }
+          ],
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'TiKV CPU Usage',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_thread_cpu_seconds_total[$__rate_interval])) by (instance)',
+              name: '{instance}'
+            }
+          ],
+          unit: 'percentunit',
+          type: 'line'
+        },
+        {
+          title: 'TiKV Memory Usage',
+          queries: [
+            {
+              query: 'process_resident_memory_bytes{job=~".*tikv"}',
+              name: '{instance}'
+            }
+          ],
+          unit: 'bytes',
+          type: 'line'
+        },
+        {
+          title: 'TiKV IO MBps',
+          queries: [
+            {
+              query:
+                'sum(rate(tikv_engine_flow_bytes{db="kv", type="wal_file_bytes"}[$__rate_interval])) by (instance) + sum(rate(tikv_engine_flow_bytes{db="raft", type="wal_file_bytes"}[$__rate_interval])) by (instance) + sum(rate(raft_engine_write_size_sum[$__rate_interval])) by (instance)',
+              name: '{instance}-write'
+            },
+            {
+              query:
+                'sum(rate(tikv_engine_flow_bytes{db="kv", type=~"bytes_read|iter_bytes_read"}[$__rate_interval])) by (instance)',
+              name: '{instance}-read'
+            }
+          ],
+          unit: 'Bps',
+          type: 'line'
+        },
+        {
+          title: 'TiKV Storage Usage',
+          queries: [
+            {
+              query: loadTiKVStoragePromql(),
+              name: '{instance}'
+            }
+          ],
+          unit: 'decbytes',
+          type: 'area_stack'
+        },
+        {
+          title: 'TiFlash Uptime',
+          queries: [
+            {
+              query: 'tiflash_system_asynchronous_metric_Uptime',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 's',
+          type: 'line'
+        },
+        {
+          title: 'TiFlash CPU Usage',
+          queries: [
+            {
+              query:
+                'rate(tiflash_proxy_process_cpu_seconds_total{job="tiflash"}[$__rate_interval])',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'percentunit',
+          type: 'line'
+        },
+        {
+          title: 'TiFlash Memory',
+          queries: [
+            {
+              query:
+                'tiflash_proxy_process_resident_memory_bytes{job="tiflash"}',
+              name: '{instance}'
+            }
+          ],
+          nullValue: TransformNullValue.AS_ZERO,
+          unit: 'bytes',
+          type: 'line'
+        },
+        {
+          title: 'TiFlash IO MBps',
+          queries: [
+            {
+              query:
+                'sum(rate(tiflash_system_profile_event_WriteBufferFromFileDescriptorWriteBytes[$__rate_interval])) by (instance) + sum(rate(tiflash_system_profile_event_PSMWriteBytes[$__rate_interval])) by (instance) + sum(rate(tiflash_system_profile_event_WriteBufferAIOWriteBytes[$__rate_interval])) by (instance)',
+              name: '{instance}-write'
+            },
+            {
+              query:
+                'sum(rate(tiflash_system_profile_event_ReadBufferFromFileDescriptorReadBytes[$__rate_interval])) by (instance) + sum(rate(tiflash_system_profile_event_PSMReadBytes[$__rate_interval])) by (instance) + sum(rate(tiflash_system_profile_event_ReadBufferAIOReadBytes[$__rate_interval])) by (instance)',
+              name: '{instance}-read'
+            }
+          ],
+          unit: 'Bps',
+          type: 'line'
+        },
+        {
+          title: 'TiFlash Storage Usage',
+          queries: [
+            {
+              query:
+                'sum(tiflash_system_current_metric_StoreSizeUsed) by (instance)',
+              name: '{instance}'
+            }
+          ],
+          unit: 'bytes',
+          type: 'area_stack'
+        }
+      ]
+    }
+  ]
+
+  return monitoringItems
+}
+
+export { getMonitoringItems }

--- a/ui/packages/tidb-dashboard-for-op/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/Monitoring/metricsQueries.ts
@@ -5,6 +5,8 @@ import {
   MetricsQueryType
 } from '@pingcap/tidb-dashboard-lib'
 
+import compareVersions from 'compare-versions'
+
 function transformColorBySQLType(legendLabel: string) {
   switch (legendLabel) {
     case 'Select':
@@ -54,7 +56,7 @@ const getMonitoringItems = (
   function loadTiKVStoragePromql() {
     const PDVersion = pdVersion?.replace('v', '')
 
-    if (PDVersion && PDVersion < '5.4.1') {
+    if (PDVersion && compareVersions.compare(PDVersion, '5.4.1', '<')) {
       return 'sum(tikv_engine_size_bytes) by (instance)'
     }
     return 'sum(tikv_store_size_bytes{type="used"}) by (instance)'

--- a/ui/packages/tidb-dashboard-for-op/src/apps/Monitoring/metricsQueries.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/Monitoring/metricsQueries.ts
@@ -5,7 +5,7 @@ import {
   MetricsQueryType
 } from '@pingcap/tidb-dashboard-lib'
 
-import compareVersions from 'compare-versions'
+import { compare } from 'compare-versions'
 
 function transformColorBySQLType(legendLabel: string) {
   switch (legendLabel) {
@@ -56,7 +56,7 @@ const getMonitoringItems = (
   function loadTiKVStoragePromql() {
     const PDVersion = pdVersion?.replace('v', '')
 
-    if (PDVersion && compareVersions.compare(PDVersion, '5.4.1', '<')) {
+    if (PDVersion && PDVersion !== 'N/A' && compare(PDVersion, '5.4.1', '<')) {
       return 'sum(tikv_engine_size_bytes) by (instance)'
     }
     return 'sum(tikv_store_size_bytes{type="used"}) by (instance)'

--- a/ui/packages/tidb-dashboard-lib/src/apps/Monitoring/components/Monitoring.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Monitoring/components/Monitoring.tsx
@@ -20,10 +20,13 @@ import { PointerEvent } from '@elastic/charts'
 import { ChartContext } from '@lib/components/MetricChart/ChartContext'
 import { useEventEmitter, useMemoizedFn } from 'ahooks'
 import { debounce } from 'lodash'
+import { store } from '@lib/utils/store'
 import { telemetry } from '../utils/telemetry'
 
 export default function Monitoring() {
   const ctx = useContext(MonitoringContext)
+  const info = store.useState((s) => s.appInfo)
+  const pdVersion = info?.version?.pd_version
   const { t } = useTranslation()
 
   const [timeRange, setTimeRange] = useState<TimeRange>(DEFAULT_TIME_RANGE)
@@ -92,7 +95,7 @@ export default function Monitoring() {
       <ChartContext.Provider value={useEventEmitter<PointerEvent>()}>
         <Stack tokens={{ childrenGap: 16 }}>
           <Card noMarginTop noMarginBottom>
-            {ctx!.cfg.metricsQueries.map((item) => (
+            {ctx!.cfg.getMetricsQueries(pdVersion).map((item) => (
               <Collapse defaultActiveKey={['1']} ghost key={item.category}>
                 <Collapse.Panel
                   header={t(`monitoring.category.${item.category}`)}

--- a/ui/packages/tidb-dashboard-lib/src/apps/Monitoring/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Monitoring/context/index.ts
@@ -22,7 +22,7 @@ export interface MetricsQueryType {
 }
 
 interface IMetricConfig {
-  metricsQueries: MetricsQueryType[]
+  getMetricsQueries: (pdVersion: string | undefined) => MetricsQueryType[]
   promeAddrConfigurable?: boolean
   timeRangeSelector?: {
     recent_seconds: number[]

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -54,6 +54,123 @@ importers:
       gulp-shell: 0.8.0
       typescript: 4.7.4
 
+  packages/tidb-dashboard-for-clinic-cloud:
+    specifiers:
+      '@ant-design/icons': ^4.7.0
+      '@baurine/esbuild-plugin-babel': ^0.3.0
+      '@baurine/esbuild-plugin-postcss3': ^0.3.3
+      '@cypress/code-coverage': ^3.9.12
+      '@cypress/skip-test': ^2.6.1
+      '@duorou_xu/speedscope': 1.14.1
+      '@fortawesome/fontawesome-free': ^6.1.1
+      '@g07cha/flexbox-react': ^5.0.0
+      '@pingcap/tidb-dashboard-client': workspace:^1.0.0
+      '@pingcap/tidb-dashboard-lib': workspace:^1.0.0
+      '@types/node': ^16.9.1
+      '@types/react': ^17.0.20
+      '@types/react-dom': ^17.0.9
+      ahooks: ^3.1.9
+      antd: ^4.18.7
+      autoprefixer: ^10.4.2
+      axios: ^0.27.2
+      babel-plugin-istanbul: ^6.1.1
+      bulma: ^0.9.4
+      chalk: 4.1.2
+      chokidar: ^3.5.2
+      classnames: ^2.3.1
+      clipboardy: 2.3.0
+      compare-versions: ^5.0.1
+      cypress: 8.5.0
+      cypress-image-snapshot: ^4.0.1
+      cypress-real-events: ^1.7.0
+      dayjs: ^1.10.8
+      dotenv: ^16.0.1
+      esbuild: ^0.14.23
+      esbuild-plugin-svgr: ^1.0.0
+      esbuild-plugin-yaml: ^0.0.1
+      eslint-plugin-cypress: ^2.12.1
+      eslint-watch: ^8.0.0
+      esm: ^3.2.25
+      eventemitter2: ^6.4.5
+      fs-extra: ^10.0.0
+      gulp: ^4.0.2
+      gulp-shell: ^0.8.0
+      http-proxy-middleware: ^2.0.6
+      i18next: ^21.6.11
+      live-server: ^1.2.1
+      mysql2: ^2.3.3
+      neat-csv: 5.1.0
+      nprogress: ^0.2.0
+      rc-animate: ^3.1.0
+      react: ^17.0.2
+      react-dom: ^17.0.2
+      react-i18next: ^11.15.4
+      react-markdown: ^8.0.3
+      react-router-dom: '6'
+      react-spring: ^8.0.27
+      react-use: ^15.3.3
+      single-spa: ^5.9.4
+      single-spa-react: ^4.6.1
+      typescript: ^4.7.3
+    dependencies:
+      '@ant-design/icons': 4.7.0_sfoxds7t5ydpegc3knd667wn6m
+      '@duorou_xu/speedscope': 1.14.1
+      '@fortawesome/fontawesome-free': 6.1.1
+      '@g07cha/flexbox-react': 5.0.0_sfoxds7t5ydpegc3knd667wn6m
+      '@pingcap/tidb-dashboard-client': link:../tidb-dashboard-client
+      '@pingcap/tidb-dashboard-lib': link:../tidb-dashboard-lib
+      ahooks: 3.5.2_react@17.0.2
+      antd: 4.21.7_sfoxds7t5ydpegc3knd667wn6m
+      axios: 0.27.2
+      bulma: 0.9.4
+      classnames: 2.3.1
+      compare-versions: 5.0.1
+      eventemitter2: 6.4.6
+      i18next: 21.8.14
+      nprogress: 0.2.0
+      rc-animate: 3.1.1_sfoxds7t5ydpegc3knd667wn6m
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-i18next: 11.18.1_gt4l4ismouzmpbvns5lg2nrrau
+      react-markdown: 8.0.3_sudpmbbyhqtxq6t4xf6jlicdem
+      react-router-dom: 6.3.0_sfoxds7t5ydpegc3knd667wn6m
+      react-spring: 8.0.27_sfoxds7t5ydpegc3knd667wn6m
+      react-use: 15.3.8_sfoxds7t5ydpegc3knd667wn6m
+      single-spa: 5.9.4
+      single-spa-react: 4.6.1_cd6sxiipx7irxcp5iyvjfmb76a
+    devDependencies:
+      '@baurine/esbuild-plugin-babel': 0.3.0
+      '@baurine/esbuild-plugin-postcss3': 0.3.3
+      '@cypress/code-coverage': 3.10.0_cypress@8.5.0
+      '@cypress/skip-test': 2.6.1
+      '@types/node': 16.11.45
+      '@types/react': 17.0.47
+      '@types/react-dom': 17.0.17
+      autoprefixer: 10.4.7
+      babel-plugin-istanbul: 6.1.1
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      clipboardy: 2.3.0
+      cypress: 8.5.0
+      cypress-image-snapshot: 4.0.1_cypress@8.5.0
+      cypress-real-events: 1.7.1_cypress@8.5.0
+      dayjs: 1.11.4
+      dotenv: 16.0.1
+      esbuild: 0.14.49
+      esbuild-plugin-svgr: 1.0.1
+      esbuild-plugin-yaml: 0.0.1
+      eslint-plugin-cypress: 2.12.1
+      eslint-watch: 8.0.0
+      esm: 3.2.25
+      fs-extra: 10.1.0
+      gulp: 4.0.2
+      gulp-shell: 0.8.0
+      http-proxy-middleware: 2.0.6
+      live-server: 1.2.2
+      mysql2: 2.3.3
+      neat-csv: 5.1.0
+      typescript: 4.7.4
+
   packages/tidb-dashboard-for-clinic-op:
     specifiers:
       '@pingcap/clinic-client': workspace:^1.0.0
@@ -121,6 +238,7 @@ importers:
       axios: ^0.27.2
       chalk: 4.1.2
       chokidar: ^3.5.2
+      compare-versions: ^5.0.1
       dotenv: ^16.0.1
       esbuild: ^0.14.23
       esbuild-plugin-svgr: ^1.0.0
@@ -144,6 +262,7 @@ importers:
       '@pingcap/tidb-dashboard-lib': link:../tidb-dashboard-lib
       antd: 4.21.7_sfoxds7t5ydpegc3knd667wn6m
       axios: 0.27.2
+      compare-versions: 5.0.1
       i18next: 21.8.14
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -166,121 +285,6 @@ importers:
       live-server: 1.2.2
       md5-file: 5.0.0
       rimraf: 3.0.2
-      typescript: 4.7.4
-
-  packages/tidb-dashboard-for-clinic-cloud:
-    specifiers:
-      '@ant-design/icons': ^4.7.0
-      '@baurine/esbuild-plugin-babel': ^0.3.0
-      '@baurine/esbuild-plugin-postcss3': ^0.3.3
-      '@cypress/code-coverage': ^3.9.12
-      '@cypress/skip-test': ^2.6.1
-      '@duorou_xu/speedscope': 1.14.1
-      '@fortawesome/fontawesome-free': ^6.1.1
-      '@g07cha/flexbox-react': ^5.0.0
-      '@pingcap/tidb-dashboard-client': workspace:^1.0.0
-      '@pingcap/tidb-dashboard-lib': workspace:^1.0.0
-      '@types/node': ^16.9.1
-      '@types/react': ^17.0.20
-      '@types/react-dom': ^17.0.9
-      ahooks: ^3.1.9
-      antd: ^4.18.7
-      autoprefixer: ^10.4.2
-      axios: ^0.27.2
-      babel-plugin-istanbul: ^6.1.1
-      bulma: ^0.9.4
-      chalk: 4.1.2
-      chokidar: ^3.5.2
-      classnames: ^2.3.1
-      clipboardy: 2.3.0
-      cypress: 8.5.0
-      cypress-image-snapshot: ^4.0.1
-      cypress-real-events: ^1.7.0
-      dayjs: ^1.10.8
-      dotenv: ^16.0.1
-      esbuild: ^0.14.23
-      esbuild-plugin-svgr: ^1.0.0
-      esbuild-plugin-yaml: ^0.0.1
-      eslint-plugin-cypress: ^2.12.1
-      eslint-watch: ^8.0.0
-      esm: ^3.2.25
-      eventemitter2: ^6.4.5
-      fs-extra: ^10.0.0
-      gulp: ^4.0.2
-      gulp-shell: ^0.8.0
-      http-proxy-middleware: ^2.0.6
-      i18next: ^21.6.11
-      live-server: ^1.2.1
-      mysql2: ^2.3.3
-      neat-csv: 5.1.0
-      nprogress: ^0.2.0
-      rc-animate: ^3.1.0
-      react: ^17.0.2
-      react-dom: ^17.0.2
-      react-i18next: ^11.15.4
-      react-markdown: ^8.0.3
-      react-router-dom: '6'
-      react-spring: ^8.0.27
-      react-use: ^15.3.3
-      single-spa: ^5.9.4
-      single-spa-react: ^4.6.1
-      typescript: ^4.7.3
-    dependencies:
-      '@ant-design/icons': 4.7.0_sfoxds7t5ydpegc3knd667wn6m
-      '@duorou_xu/speedscope': 1.14.1
-      '@fortawesome/fontawesome-free': 6.1.1
-      '@g07cha/flexbox-react': 5.0.0_sfoxds7t5ydpegc3knd667wn6m
-      '@pingcap/tidb-dashboard-client': link:../tidb-dashboard-client
-      '@pingcap/tidb-dashboard-lib': link:../tidb-dashboard-lib
-      ahooks: 3.5.2_react@17.0.2
-      antd: 4.21.7_sfoxds7t5ydpegc3knd667wn6m
-      axios: 0.27.2
-      bulma: 0.9.4
-      classnames: 2.3.1
-      eventemitter2: 6.4.6
-      i18next: 21.8.14
-      nprogress: 0.2.0
-      rc-animate: 3.1.1_sfoxds7t5ydpegc3knd667wn6m
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-i18next: 11.18.1_gt4l4ismouzmpbvns5lg2nrrau
-      react-markdown: 8.0.3_sudpmbbyhqtxq6t4xf6jlicdem
-      react-router-dom: 6.3.0_sfoxds7t5ydpegc3knd667wn6m
-      react-spring: 8.0.27_sfoxds7t5ydpegc3knd667wn6m
-      react-use: 15.3.8_sfoxds7t5ydpegc3knd667wn6m
-      single-spa: 5.9.4
-      single-spa-react: 4.6.1_cd6sxiipx7irxcp5iyvjfmb76a
-    devDependencies:
-      '@baurine/esbuild-plugin-babel': 0.3.0
-      '@baurine/esbuild-plugin-postcss3': 0.3.3
-      '@cypress/code-coverage': 3.10.0_cypress@8.5.0
-      '@cypress/skip-test': 2.6.1
-      '@types/node': 16.11.45
-      '@types/react': 17.0.47
-      '@types/react-dom': 17.0.17
-      autoprefixer: 10.4.7
-      babel-plugin-istanbul: 6.1.1
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      clipboardy: 2.3.0
-      cypress: 8.5.0
-      cypress-image-snapshot: 4.0.1_cypress@8.5.0
-      cypress-real-events: 1.7.1_cypress@8.5.0
-      dayjs: 1.11.4
-      dotenv: 16.0.1
-      esbuild: 0.14.49
-      esbuild-plugin-svgr: 1.0.1
-      esbuild-plugin-yaml: 0.0.1
-      eslint-plugin-cypress: 2.12.1
-      eslint-watch: 8.0.0
-      esm: 3.2.25
-      fs-extra: 10.1.0
-      gulp: 4.0.2
-      gulp-shell: 0.8.0
-      http-proxy-middleware: 2.0.6
-      live-server: 1.2.2
-      mysql2: 2.3.3
-      neat-csv: 5.1.0
       typescript: 4.7.4
 
   packages/tidb-dashboard-for-op:
@@ -308,6 +312,7 @@ importers:
       chokidar: ^3.5.2
       classnames: ^2.3.1
       clipboardy: 2.3.0
+      compare-versions: ^5.0.1
       cypress: 8.5.0
       cypress-image-snapshot: ^4.0.1
       cypress-real-events: ^1.7.0
@@ -352,6 +357,7 @@ importers:
       axios: 0.27.2
       bulma: 0.9.4
       classnames: 2.3.1
+      compare-versions: 5.0.1
       eventemitter2: 6.4.6
       i18next: 21.8.14
       nprogress: 0.2.0
@@ -4501,6 +4507,10 @@ packages:
     resolution: {integrity: sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg==}
     dev: true
 
+  /compare-versions/5.0.1:
+    resolution: {integrity: sha512-v8Au3l0b+Nwkp4G142JcgJFh1/TUhdxut7wzD1Nq1dyp5oa3tXaqb03EXOAB6jS4gMlalkjAUPZBMiAfKUixHQ==}
+    dev: false
+
   /component-emitter/1.3.0:
     resolution: {integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==}
     dev: true
@@ -5407,7 +5417,7 @@ packages:
     dev: false
 
   /ee-first/1.1.1:
-    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
     dev: true
 
   /electron-to-chromium/1.4.195:
@@ -6672,7 +6682,7 @@ packages:
     dev: true
 
   /fresh/0.5.2:
-    resolution: {integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=}
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
     dev: true
 


### PR DESCRIPTION
What this PR does:

- make promql version compatible
  `version >= 5.4.1`, promql: `sum(tikv_store_size_bytes{type="used"}) by (instance)`
  `version < 5.4.1`, promql: `sum(tikv_engine_size_bytes) by (instance)`
-  update TiFlash IO MBps: add `by (instance)` for each sum operation
- Sync metricsQueries of `tidb-dashboard-for-clinic-cloud` with the one of `tidb-dashboard-for-dbaas`.