### PR TITLE
support reset order for statement and slow query

### DIFF
--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
@@ -26,7 +26,8 @@ import {
   Toolbar,
   MultiSelect,
   TimeRange,
-  toTimeRangeValue
+  toTimeRangeValue,
+  IColumnKeys
 } from '@lib/components'
 import { CacheContext } from '@lib/utils/useCache'
 import { useVersionedLocalStorageState } from '@lib/utils/useVersionedLocalStorageState'
@@ -75,6 +76,12 @@ function List() {
 
     ds: ctx!.ds
   })
+  function updateVisibleColumnKeys(v: IColumnKeys) {
+    setVisibleColumnKeys(v)
+    if (v[controller.orderOptions.orderBy] !== true) {
+      controller.resetOrder()
+    }
+  }
 
   function menuItemClick({ key }) {
     switch (key) {
@@ -222,7 +229,7 @@ function List() {
                 columns={controller.availableColumnsInTable}
                 visibleColumnKeys={visibleColumnKeys}
                 defaultVisibleColumnKeys={DEF_SLOW_QUERY_COLUMN_KEYS}
-                onChange={setVisibleColumnKeys}
+                onChange={updateVisibleColumnKeys}
                 foot={
                   <Checkbox
                     checked={showFullSQL}

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
@@ -78,7 +78,7 @@ function List() {
   })
   function updateVisibleColumnKeys(v: IColumnKeys) {
     setVisibleColumnKeys(v)
-    if (v[controller.orderOptions.orderBy] !== true) {
+    if (!v[controller.orderOptions.orderBy]) {
       controller.resetOrder()
     }
   }

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/utils/useSlowQueryTableController.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/utils/useSlowQueryTableController.ts
@@ -106,6 +106,7 @@ export interface ISlowQueryTableController {
 
   orderOptions: IOrderOptions
   changeOrder: (orderBy: string, desc: boolean) => void
+  resetOrder: () => void
 
   isLoading: boolean
 
@@ -133,6 +134,9 @@ export default function useSlowQueryTableController({
     persistQueryInSession,
     DEF_ORDER_OPTIONS
   )
+  function resetOrder() {
+    changeOrder(DEF_ORDER_OPTIONS.orderBy, DEF_ORDER_OPTIONS.desc)
+  }
 
   const { queryOptions, setQueryOptions } = useQueryOptions(
     initialQueryOptions,
@@ -274,6 +278,7 @@ export default function useSlowQueryTableController({
 
     orderOptions,
     changeOrder,
+    resetOrder,
 
     isLoading: isColumnsLoading || isDataLoading || isOptionsLoading,
 

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
@@ -30,7 +30,8 @@ import {
   TimeRangeSelector,
   TimeRange,
   DateTime,
-  toTimeRangeValue
+  toTimeRangeValue,
+  IColumnKeys
 } from '@lib/components'
 import { useVersionedLocalStorageState } from '@lib/utils/useVersionedLocalStorageState'
 import { StatementsTable } from '../../components'
@@ -99,6 +100,14 @@ export default function StatementsOverview() {
     },
     ds: ctx!.ds
   })
+  function updateVisibleColumnKeys(v: IColumnKeys) {
+    setVisibleColumnKeys(v)
+    stmtTelmetry.changeVisibleColumns(v)
+
+    if (v[controller.orderOptions.orderBy] !== true) {
+      controller.resetOrder()
+    }
+  }
 
   function menuItemClick({ key }) {
     switch (key) {
@@ -266,10 +275,7 @@ export default function StatementsOverview() {
                 columns={controller.availableColumnsInTable}
                 visibleColumnKeys={visibleColumnKeys}
                 defaultVisibleColumnKeys={DEF_STMT_COLUMN_KEYS}
-                onChange={(v) => {
-                  setVisibleColumnKeys(v)
-                  stmtTelmetry.changeVisibleColumns(v)
-                }}
+                onChange={updateVisibleColumnKeys}
                 foot={
                   <Checkbox
                     checked={showFullSQL}

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
@@ -104,7 +104,7 @@ export default function StatementsOverview() {
     setVisibleColumnKeys(v)
     stmtTelmetry.changeVisibleColumns(v)
 
-    if (v[controller.orderOptions.orderBy] !== true) {
+    if (!v[controller.orderOptions.orderBy]) {
       controller.resetOrder()
     }
   }

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/utils/useStatementTableController.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/utils/useStatementTableController.ts
@@ -105,6 +105,7 @@ export interface IStatementTableController {
 
   orderOptions: IOrderOptions
   changeOrder: (orderBy: string, desc: boolean) => void
+  resetOrder: () => void
 
   isEnabled: boolean // returned from backend
   isLoading: boolean
@@ -133,6 +134,9 @@ export default function useStatementTableController({
     persistQueryInSession,
     DEF_ORDER_OPTIONS
   )
+  function resetOrder() {
+    changeOrder(DEF_ORDER_OPTIONS.orderBy, DEF_ORDER_OPTIONS.desc)
+  }
 
   const { queryOptions, setQueryOptions } = useQueryOptions(
     initialQueryOptions,
@@ -287,6 +291,7 @@ export default function useStatementTableController({
 
     orderOptions,
     changeOrder,
+    resetOrder,
 
     isEnabled,
     isLoading: isColumnsLoading || isDataLoading || isOptionsLoading,


### PR DESCRIPTION
## What Did

If the column used for order changes to be invisible, then reset the order column.