### PR TITLE
refine: improve compatibility

### DIFF
--- a/ui/packages/tidb-dashboard-for-clinic-cloud/package.json
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pingcap/tidb-dashboard-for-clinic-cloud",
-  "version": "0.0.24",
+  "version": "0.0.26",
   "main": "dist/dashboardApp.js",
   "module": "dist/dashboardApp.js",
   "files": [

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/DebugAPI/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/DebugAPI/context.ts
@@ -16,8 +16,9 @@ class DataSource implements IDebugAPIDataSource {
       {
         req: {
           ...req,
-          // to compatible with the old tidb-dashboard backend api, for example: v5.0.6
-          // id -> api_id, params -> param_values
+          // To compatible with the old tidb-dashboard backend api before 5.4.0
+          // By PR https://github.com/pingcap/tidb-dashboard/pull/1103 (release to v2021.12.30.1 and PD 5.4.0)
+          // It changes `id` to `api_id`, `params` to `param_values`
           id: req.api_id,
           params: req.param_values
         } as any

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Statement/context.ts
@@ -1,10 +1,8 @@
 import {
   IStatementDataSource,
   IStatementContext,
-  ReqConfig,
-  StatementTimeRange
+  ReqConfig
 } from '@pingcap/tidb-dashboard-lib'
-import { AxiosPromise } from 'axios'
 
 import client, {
   StatementEditableConfig,

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Statement/context.ts
@@ -1,8 +1,10 @@
 import {
   IStatementDataSource,
   IStatementContext,
-  ReqConfig
+  ReqConfig,
+  StatementTimeRange
 } from '@pingcap/tidb-dashboard-lib'
+import { AxiosPromise } from 'axios'
 
 import client, {
   StatementEditableConfig,
@@ -101,6 +103,10 @@ class DataSource implements IStatementDataSource {
 
   statementsStmtTypesGet(options?: ReqConfig) {
     return client.getInstance().statementsStmtTypesGet(options)
+  }
+
+  statementsTimeRangesGet(options?: ReqConfig) {
+    return client.getAxiosInstance().get('/statements/time_ranges', options)
   }
 
   // slow query

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/client/index.tsx
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/client/index.tsx
@@ -18,9 +18,14 @@ export * from '@pingcap/tidb-dashboard-client'
 //////////////////////////////
 
 const client = {
-  init(apiBasePath: string, apiInstance: DashboardApi) {
+  init(
+    apiBasePath: string,
+    apiInstance: DashboardApi,
+    axiosInstance: AxiosInstance
+  ) {
     this.apiBasePath = apiBasePath
     this.apiInstance = apiInstance
+    this.axiosInstance = axiosInstance
   },
 
   getInstance(): DashboardApi {
@@ -29,6 +34,10 @@ const client = {
 
   getBasePath(): string {
     return this.apiBasePath
+  },
+
+  getAxiosInstance(): AxiosInstance {
+    return this.axiosInstance
   }
 }
 
@@ -123,7 +132,10 @@ function initAxios(clientOptions: ClientOptions, clusterInfo: ClusterInfo) {
   if (deployType) {
     headers['x-deploy-type'] = deployType
   }
-  const instance = axios.create({ headers })
+  const instance = axios.create({
+    baseURL: clientOptions.apiPathBase,
+    headers
+  })
   applyErrorHandlerInterceptor(instance)
 
   return instance
@@ -147,5 +159,5 @@ export function setupClient(
     axiosInstance
   )
 
-  client.init(clientOptions.apiPathBase, dashboardApi)
+  client.init(clientOptions.apiPathBase, dashboardApi, axiosInstance)
 }

--- a/ui/packages/tidb-dashboard-for-dbaas/package.json
+++ b/ui/packages/tidb-dashboard-for-dbaas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pingcap/tidb-dashboard-for-dbaas",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "main": "dist/main.js",
   "module": "dist/main.js",
   "files": [

--- a/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/context.ts
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/context.ts
@@ -25,9 +25,6 @@ class DataSource implements IMonitoringDataSource {
         .get<MetricsQueryResponse>(
           this.globalConfig.promBaseUrl + '/api/v1/query_range',
           {
-            headers: {
-              Authorization: `Bearer ${this.globalConfig.apiToken}`
-            },
             params: {
               query: params.query,
               step: params.stepSec,

--- a/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/context.ts
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/apps/Monitoring/context.ts
@@ -21,7 +21,7 @@ class DataSource implements IMonitoringDataSource {
   }) => {
     if (this.globalConfig.promBaseUrl) {
       return client
-        .getAxiosInstace()
+        .getAxiosInstance()
         .get<MetricsQueryResponse>(
           this.globalConfig.promBaseUrl + '/api/v1/query_range',
           {

--- a/ui/packages/tidb-dashboard-for-dbaas/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/apps/Statement/context.ts
@@ -104,7 +104,7 @@ class DataSource implements IStatementDataSource {
   }
 
   statementsTimeRangesGet(options?: ReqConfig) {
-    return client.getAxiosInstace().get('/statements/time_ranges', options)
+    return client.getAxiosInstance().get('/statements/time_ranges', options)
   }
 
   // slow query

--- a/ui/packages/tidb-dashboard-for-dbaas/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/apps/Statement/context.ts
@@ -103,6 +103,10 @@ class DataSource implements IStatementDataSource {
     return client.getInstance().statementsStmtTypesGet(options)
   }
 
+  statementsTimeRangesGet(options?: ReqConfig) {
+    return client.getAxiosInstace().get('/statements/time_ranges', options)
+  }
+
   // slow query
   slowQueryAvailableFieldsGet(options?: ReqConfig) {
     return client.getInstance().slowQueryAvailableFieldsGet(options)

--- a/ui/packages/tidb-dashboard-for-dbaas/src/client/index.tsx
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/client/index.tsx
@@ -105,8 +105,13 @@ function applyErrorHandlerInterceptor(instance: AxiosInstance) {
   })
 }
 
-function initAxios() {
-  const instance = axios.create()
+function initAxios(apiBasePath: string, token: string) {
+  const instance = axios.create({
+    baseURL: apiBasePath,
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  })
   applyErrorHandlerInterceptor(instance)
 
   return instance
@@ -115,7 +120,7 @@ function initAxios() {
 export function setupClient(apiBasePath: string, token: string) {
   i18n.addTranslations(translations)
 
-  const axiosInstance = initAxios()
+  const axiosInstance = initAxios(apiBasePath, token)
   const dashboardApi = new DashboardApi(
     new Configuration({
       basePath: apiBasePath,

--- a/ui/packages/tidb-dashboard-for-dbaas/src/client/index.tsx
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/client/index.tsx
@@ -34,7 +34,7 @@ const client = {
     return this.apiBasePath
   },
 
-  getAxiosInstace(): AxiosInstance {
+  getAxiosInstance(): AxiosInstance {
     return this.axiosInstance
   }
 }

--- a/ui/packages/tidb-dashboard-for-op/src/apps/DebugAPI/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/DebugAPI/context.ts
@@ -12,7 +12,19 @@ class DataSource implements IDebugAPIDataSource {
   }
 
   debugAPIRequestEndpoint(req: EndpointRequestPayload, options?: ReqConfig) {
-    return client.getInstance().debugAPIRequestEndpoint({ req }, options)
+    return client.getInstance().debugAPIRequestEndpoint(
+      {
+        req: {
+          ...req,
+          // To compatible with the old tidb-dashboard backend api before 5.4.0
+          // By PR https://github.com/pingcap/tidb-dashboard/pull/1103 (release to v2021.12.30.1 and PD 5.4.0)
+          // It changes `id` to `api_id`, `params` to `param_values`
+          id: req.api_id,
+          params: req.param_values
+        } as any
+      },
+      options
+    )
   }
 
   infoListDatabases(options?: ReqConfig) {

--- a/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
@@ -105,7 +105,7 @@ class DataSource implements IStatementDataSource {
   }
 
   statementsTimeRangesGet(options?: ReqConfig) {
-    return client.getAxiosInstace().get('/statements/time_ranges', {
+    return client.getAxiosInstance().get('/statements/time_ranges', {
       ...options,
       headers: {
         ...options?.headers,

--- a/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
@@ -8,6 +8,7 @@ import client, {
   StatementEditableConfig,
   StatementGetStatementsRequest
 } from '~/client'
+import auth from '~/uilts/auth'
 
 class DataSource implements IStatementDataSource {
   infoListDatabases(options?: ReqConfig) {
@@ -101,6 +102,16 @@ class DataSource implements IStatementDataSource {
 
   statementsStmtTypesGet(options?: ReqConfig) {
     return client.getInstance().statementsStmtTypesGet(options)
+  }
+
+  statementsTimeRangesGet(options?: ReqConfig) {
+    return client.getAxiosInstace().get('/statements/time_ranges', {
+      ...options,
+      headers: {
+        ...options?.headers,
+        Authorization: auth.getAuthTokenAsBearer() || ''
+      }
+    })
   }
 
   // slow query

--- a/ui/packages/tidb-dashboard-for-op/src/client/index.tsx
+++ b/ui/packages/tidb-dashboard-for-op/src/client/index.tsx
@@ -20,9 +20,14 @@ export * from '@pingcap/tidb-dashboard-client'
 //////////////////////////////
 
 const client = {
-  init(apiBasePath: string, apiInstance: DashboardApi) {
+  _init(
+    apiBasePath: string,
+    apiInstance: DashboardApi,
+    axiosInstance: AxiosInstance
+  ) {
     this.apiBasePath = apiBasePath
     this.apiInstance = apiInstance
+    this.axiosInstance = axiosInstance
   },
 
   getInstance(): DashboardApi {
@@ -31,6 +36,10 @@ const client = {
 
   getBasePath(): string {
     return this.apiBasePath
+  },
+
+  getAxiosInstace(): AxiosInstance {
+    return this.axiosInstance
   }
 }
 
@@ -105,8 +114,10 @@ function applyErrorHandlerInterceptor(instance: AxiosInstance) {
   })
 }
 
-function initAxios() {
-  const instance = axios.create()
+function initAxios(apiBasePath: string) {
+  const instance = axios.create({
+    baseURL: apiBasePath
+  })
   applyErrorHandlerInterceptor(instance)
 
   return instance
@@ -116,7 +127,7 @@ function init() {
   i18n.addTranslations(translations)
 
   const apiBasePath = getApiBasePath()
-  const axiosInstance = initAxios()
+  const axiosInstance = initAxios(apiBasePath)
   const dashboardApi = new DashboardApi(
     new Configuration({
       basePath: apiBasePath,
@@ -129,7 +140,7 @@ function init() {
     axiosInstance
   )
 
-  client.init(apiBasePath, dashboardApi)
+  client._init(apiBasePath, dashboardApi, axiosInstance)
 }
 
 init()

--- a/ui/packages/tidb-dashboard-for-op/src/client/index.tsx
+++ b/ui/packages/tidb-dashboard-for-op/src/client/index.tsx
@@ -65,7 +65,10 @@ function applyErrorHandlerInterceptor(instance: AxiosInstance) {
     err.message = content
     err.errCode = errCode
 
-    if (errCode === 'common.unauthenticated') {
+    if (
+      errCode === 'common.unauthenticated' ||
+      errCode === 'error.api.unauthorized' // compatible with old tidb-dashboard backend
+    ) {
       // Handle unauthorized error in a unified way
       if (!routing.isLocationMatch('/') && !routing.isSignInPage()) {
         message.error({ content, key: errCode })

--- a/ui/packages/tidb-dashboard-for-op/src/client/index.tsx
+++ b/ui/packages/tidb-dashboard-for-op/src/client/index.tsx
@@ -38,7 +38,7 @@ const client = {
     return this.apiBasePath
   },
 
-  getAxiosInstace(): AxiosInstance {
+  getAxiosInstance(): AxiosInstance {
     return this.axiosInstance
   }
 }

--- a/ui/packages/tidb-dashboard-for-op/src/dashboardApp/layout/signin/index.tsx
+++ b/ui/packages/tidb-dashboard-for-op/src/dashboardApp/layout/signin/index.tsx
@@ -466,7 +466,9 @@ function App({ registry }) {
   useEffect(() => {
     async function run() {
       try {
-        const resp = await client.getInstance().userGetLoginInfo()
+        const resp = await client
+          .getInstance()
+          .userGetLoginInfo({ handleError: 'custom' } as any)
         const loginInfo = resp.data
         if (
           (loginInfo.supported_auth_types?.indexOf(auth.AuthTypes.SSO) ?? -1) >
@@ -478,12 +480,16 @@ function App({ registry }) {
         }
         setSupportedAuthTypes(loginInfo.supported_auth_types ?? [])
       } catch (e) {
-        Modal.error({
-          title: 'Initialize Sign in failed',
-          content: '' + e,
-          okText: 'Reload',
-          onOk: () => window.location.reload()
-        })
+        if ((e as any).response?.status === 404) {
+          setFormType(DisplayFormType.tidbCredential)
+        } else {
+          Modal.error({
+            title: 'Initialize Sign in failed',
+            content: '' + e,
+            okText: 'Reload',
+            onOk: () => window.location.reload()
+          })
+        }
       }
     }
     run()

--- a/ui/packages/tidb-dashboard-lib/src/apps/DebugAPI/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/DebugAPI/translations/en.yaml
@@ -33,16 +33,44 @@ debug_api:
       tidb_hot_regions: Region - Hot
       tidb_pprof: pprof
       tidb_pprof_desc: The `seconds` parameter is only effective to `kind=profile` and `kind=trace`.
+
+      # for old tidb-dashboard backend api before 5.4.0
+      # get back from https://github.com/pingcap/tidb-dashboard/pull/1103/files#diff-fc455ec052d6f881db40d33377d3a6cd757100b476f10eb68ca5e72696e8a463L23
+      tidb_stats_dump: Statistics Data - of a Table
+      tidb_stats_dump_timestamp: Statistics Data - of a Table and Timestamp
+      tidb_stats_dump_timestamp_desc: The timestamp needs to be set within the GC safe point
+      tidb_config: Current Config
+      # tidb_schema: Schema Information - All / by TableID
+      tidb_schema_db: Schema Information - by Database
+      tidb_schema_db_table: Schema Information - by Database + Table
+      tidb_dbtable_tableid: Schema and Table Information - by TableID
+      # tidb_ddl_history: DDL History - All
+      tidb_info: Server Information - Current
+      tidb_info_all: Server Information - All Servers
+      tidb_regions_meta: Region - All
+      tidb_region_id: Region - by RegionID
+      # tidb_table_regions: Region - by Database + Table
+      # tidb_hot_regions: Region - Hot
+      # tidb_pprof: pprof
+      # tidb_pprof_desc: The `seconds` parameter is only effective to `kind=profile` and `kind=trace`.
   tikv:
     name: '{{distro.tikv}}'
     endpoints:
       tikv_config: Current Config
       tikv_pprof_profile: CPU Profiling
+
+      # for old tidb-dashboard backend api before 5.4.0
+      # tikv_config: Current Config
+      tikv_profile: CPU Profiling
   tiflash:
     name: '{{distro.tiflash}}'
     endpoints:
       tiflash_config: Current Config
       tiflash_pprof_profile: CPU Profiling
+
+      # for old tidb-dashboard backend api before 5.4.0
+      # tiflash_config: Current Config
+      tiflash_profile: CPU Profiling
   pd:
     name: '{{distro.pd}}'
     endpoints:
@@ -74,3 +102,35 @@ debug_api:
       pd_store_by_id: Store - by StoreID (pd-ctl store [id])
       pd_pprof: pprof
       pd_pprof_desc: The `seconds` parameter is only effective to `kind=profile` and `kind=trace`.
+
+      # for old tidb-dashboard backend api before 5.4.0
+      pd_cluster: Cluster Information (pd-ctl cluster)
+      # pd_cluster_status: Cluster Status
+      pd_config_show_all: Current Config
+      # pd_health: Cluster Health Information (pd-ctl health)
+      # pd_hot_read: Hot - Read (pd-ctl hot read)
+      # pd_hot_write: Hot - Write (pd-ctl hot write)
+      # pd_hot_stores: Hot - Stores (pd-ctl hot store)
+      pd_labels: All Labels (pd-ctl label)
+      pd_members_show: All Members Information (pd-ctl member)
+      pd_leader_show: Leader Information (pd-ctl member leader show)
+      pd_operator_show: All Operators (pd-ctl operator show)
+      pd_regions: Regions - All (pd-ctl region)
+      pd_region_id: Region - by RegionID (pd-ctl region [id])
+      pd_region_key: Region - by Key Reside in (pd-ctl region key [key])
+      pd_region_scan: Regions - Scan All (pd-ctl region scan)
+      pd_region_sibling: Regions - Sibling Regions by RegionID (pd-ctl region sibling [id])
+      # pd_regions_store: Regions - All Regions of a Store (pd-ctl region store [store-id])
+      pd_region_start_key: Regions - All Regions Starting from a Key (pd-ctl region startkey [key])
+      pd_region_top_read: Regions - Top Read Flow (pd-ctl region topread)
+      pd_region_top_write: Regions - Top Write Flow (pd-ctl region topread)
+      pd_region_top_conf_ver: Regions - Top Conf Version (pd-ctl region topconfver)
+      pd_region_top_version: Regions - Top Version (pd-ctl region topversion)
+      pd_region_top_size: Regions - Top Size (pd-ctl region topsize)
+      pd_region_check: Regions - by State (region check [state])
+      pd_scheduler_show: All Schedulers (pd-ctl scheduler show)
+      pd_stores: Stores - All (pd-ctl store)
+      pd_label_stores: Stores - by Label (pd-ctl label store [name] [value])
+      pd_store_id: Store - by StoreID (pd-ctl store [id])
+      # pd_pprof: pprof
+      # pd_pprof_desc: The `seconds` parameter is only effective to `kind=profile` and `kind=trace`.

--- a/ui/packages/tidb-dashboard-lib/src/apps/DebugAPI/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/DebugAPI/translations/zh.yaml
@@ -17,6 +17,9 @@ debug_api:
     endpoints:
       tidb_stats_by_table_timestamp_desc: 时间戳应当在 GC Safe Point 以后
       tidb_pprof_desc: seconds 参数仅对 kind=profile 和 kind=trace 生效
+
+      # for old tidb-dashboard backend api before 5.4.0
+      tidb_stats_dump_timestamp_desc: 时间戳应当在 GC Safe Point 以后
   pd:
     endpoints:
       pd_pprof_desc: seconds 参数仅对 kind=profile 和 kind=trace 生效

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/context/index.ts
@@ -11,6 +11,11 @@ import {
 import { IContextConfig, ReqConfig } from '@lib/types'
 import { ISlowQueryDataSource } from '@lib/apps/SlowQuery'
 
+export type StatementTimeRange = {
+  begin_time: number
+  end_time: number
+}
+
 export interface IStatementDataSource extends ISlowQueryDataSource {
   statementsAvailableFieldsGet(options?: ReqConfig): AxiosPromise<Array<string>>
 
@@ -58,6 +63,10 @@ export interface IStatementDataSource extends ISlowQueryDataSource {
   ): AxiosPromise<Array<StatementModel>>
 
   statementsStmtTypesGet(options?: ReqConfig): AxiosPromise<Array<string>>
+
+  statementsTimeRangesGet(
+    options?: ReqConfig
+  ): AxiosPromise<Array<StatementTimeRange>>
 }
 
 export interface IStatementContext {

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/utils/useStatementTableController.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/utils/useStatementTableController.ts
@@ -274,9 +274,9 @@ export default function useStatementTableController({
         }
         // if we have checked it is new backend (aka oldBackend === false)
         // we don't check it again
-        if (oldBackend) {
+        if (oldBackend && data.list[0]) {
           // old backend api has no `summary_begin_time` field
-          setOldBackend(data.list[0]?.summary_begin_time === undefined)
+          setOldBackend(data.list[0].summary_begin_time === undefined)
         }
         setData(data)
         setErrors([])

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/utils/useStatementTableController.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/utils/useStatementTableController.ts
@@ -154,7 +154,9 @@ export default function useStatementTableController({
   )
 
   // By PR https://github.com/pingcap/tidb-dashboard/pull/1234 (feat: improve statement)
+  // which brings in v2022.05.16.1 and PD >=5.4.2, >=6.1.0
   // The statement API logic changes a bit
+  // related code: https://github.com/pingcap/tidb-dashboard/pull/1234/files#diff-4bebd6011f602ac611ee19697803dc09877df197bf0176d1f27f84133b15e68bR54
   // The new UI can't work with the old tidb-dashboard backend API well
   // So we try to make the new UI compatible with the old tidb-dashboard backend
   // By enlarging the selected time range with window size


### PR DESCRIPTION
## What Did

Make new ui can work with old tidb-dashboard backend

- improve compatibility for statement, work with old tidb-dashboard backend early to at least 5.0.0
- improve compatibility for debug api, work with old-tidb-dashboard backend early to 5.0.3
- improve compatibility for sign in

statement changes its api by PR #1234 , brings to >=5.4.2 and >=6.1.0

debug api is first introduced in 5.0.0 and changes its api in 5.0.3 ( by PR #927 ) and 5.4.0 ( by PR #1103 )


