### PR TITLE
refine: client init

### DIFF
--- a/ui/packages/tidb-dashboard-for-clinic-cloud/package.json
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pingcap/tidb-dashboard-for-clinic-cloud",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "main": "dist/dashboardApp.js",
   "module": "dist/dashboardApp.js",
   "files": [

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/client/index.tsx
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/client/index.tsx
@@ -155,8 +155,9 @@ export function setupClient(
       }
     }),
     // basePath, it's set in the axiosInstance, so we pass empty string to dashboard Api
-    // else the final api path will be the value the combined by dashboardApi basePath and axiosInstance baseURL
-    // if we use undefined, dashboardApi basePath will be the default value `/dashboard/api`
+    // if basePath and baseURL are both relative path
+    // the final api path will be the value that combined by dashboardApi basePath and axiosInstance baseURL
+    // if we use undefined for this param, dashboardApi basePath will be the default value `/dashboard/api`
     '',
     axiosInstance
   )

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/client/index.tsx
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/client/index.tsx
@@ -150,12 +150,14 @@ export function setupClient(
   const axiosInstance = initAxios(clientOptions, clusterInfo)
   const dashboardApi = new DashboardApi(
     new Configuration({
-      basePath: clientOptions.apiPathBase,
       baseOptions: {
         handleError: 'default'
       }
     }),
-    undefined,
+    // basePath, it's set in the axiosInstance, so we pass empty string to dashboard Api
+    // else the final api path will be the value the combined by dashboardApi basePath and axiosInstance baseURL
+    // if we use undefined, dashboardApi basePath will be the default value `/dashboard/api`
+    '',
     axiosInstance
   )
 

--- a/ui/packages/tidb-dashboard-for-dbaas/src/client/index.tsx
+++ b/ui/packages/tidb-dashboard-for-dbaas/src/client/index.tsx
@@ -123,13 +123,11 @@ export function setupClient(apiBasePath: string, token: string) {
   const axiosInstance = initAxios(apiBasePath, token)
   const dashboardApi = new DashboardApi(
     new Configuration({
-      basePath: apiBasePath,
-      apiKey: `Bearer ${token}`,
       baseOptions: {
         handleError: 'default'
       }
     }),
-    undefined,
+    '',
     axiosInstance
   )
 

--- a/ui/packages/tidb-dashboard-for-op/src/client/index.tsx
+++ b/ui/packages/tidb-dashboard-for-op/src/client/index.tsx
@@ -130,13 +130,12 @@ function init() {
   const axiosInstance = initAxios(apiBasePath)
   const dashboardApi = new DashboardApi(
     new Configuration({
-      basePath: apiBasePath,
       apiKey: () => auth.getAuthTokenAsBearer() || '',
       baseOptions: {
         handleError: 'default'
       }
     }),
-    undefined,
+    '',
     axiosInstance
   )
 


### PR DESCRIPTION
## What Did

- Fix client setting for tidb-dashboard-for-clinic-cloud, fix the wrong final api path
- Refine client setting for other variant, dismiss duplicated setting for basePath

Related PR: #1431 