### PR TITLE
chore: update tooltip when failed to get host info

### DIFF
--- a/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/components/DiskTable.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/components/DiskTable.tsx
@@ -104,7 +104,7 @@ export default function HostTable() {
               <Tooltip
                 title={t('cluster_info.list.host_table.instanceUnavailable')}
               >
-                <Typography.Text type="danger">
+                <Typography.Text type="warning">
                   <WarningOutlined /> {row.host}
                 </Typography.Text>
               </Tooltip>

--- a/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/components/HostTable.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/components/HostTable.tsx
@@ -71,7 +71,7 @@ export default function HostTable() {
               <Tooltip
                 title={t('cluster_info.list.host_table.instanceUnavailable')}
               >
-                <Typography.Text type="danger">
+                <Typography.Text type="warning">
                   <WarningOutlined /> {row.host}
                 </Typography.Text>
               </Tooltip>

--- a/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/translations/en.yaml
@@ -24,7 +24,7 @@ cluster_info:
         memory: Memory
         memory_usage: Memory Usage
         instances: Instances
-      instanceUnavailable: Host information is unavailable due to instances on the host is down
+      instanceUnavailable: Failed to get the host information
     disk_table:
       title: Disks
       columns:

--- a/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/translations/zh.yaml
@@ -24,7 +24,7 @@ cluster_info:
         memory: 物理内存
         memory_usage: 内存使用率
         instances: 实例
-      instanceUnavailable: 由于该主机上没有实例存活，因此无法获取主机信息
+      instanceUnavailable: 获取主机信息失败
     disk_table:
       title: 磁盘
       columns:


### PR DESCRIPTION
close #926 

## What Did

- Update tooltip when failed to get host info, because the reason is not correct in some cases

## Preview

![screenshot-20230113-181225](https://user-images.githubusercontent.com/1284531/212295773-f4988166-7754-4e60-b9c0-3519882d4784.png)
