### PR TITLE
Add one-click bind plan on sql statement detail page

### DIFF
--- a/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
@@ -114,17 +114,35 @@ class DataSource implements IStatementDataSource {
     })
   }
 
-  statementsPlanBindInfoGet(
-    digest: string,
+  statementsPlanBindStatusGet(
+    sqlDigest: string,
     beginTime: number,
     endTime: number,
     options?: ReqConfig
   ) {
     return client.getInstance().statementsPlanBindingGet(
       {
-        sqlDigest: digest,
+        sqlDigest,
         beginTime,
         endTime
+      },
+      options
+    )
+  }
+
+  statementsPlanBindCreate(planDigest: string, options?: ReqConfig) {
+    return client.getInstance().statementsPlanBindingPost(
+      {
+        planDigest
+      },
+      options
+    )
+  }
+
+  statementsPlanBindDelete(sqlDigest: string, options?: ReqConfig) {
+    return client.getInstance().statementsPlanBindingDelete(
+      {
+        sqlDigest
       },
       options
     )
@@ -190,5 +208,9 @@ const ds = new DataSource()
 
 export const ctx: IStatementContext = {
   ds,
-  cfg: { apiPathBase: client.getBasePath(), enableExport: true }
+  cfg: {
+    apiPathBase: client.getBasePath(),
+    enableExport: true,
+    enablePlanBinding: true
+  }
 }

--- a/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
@@ -114,6 +114,22 @@ class DataSource implements IStatementDataSource {
     })
   }
 
+  statementsPlanBindInfoGet(
+    digest: string,
+    beginTime: number,
+    endTime: number,
+    options?: ReqConfig
+  ) {
+    return client.getInstance().statementsPlanBindingGet(
+      {
+        sqlDigest: digest,
+        beginTime,
+        endTime
+      },
+      options
+    )
+  }
+
   // slow query
   slowQueryAvailableFieldsGet(options?: ReqConfig) {
     return client.getInstance().slowQueryAvailableFieldsGet(options)

--- a/ui/packages/tidb-dashboard-for-op/src/client/index.tsx
+++ b/ui/packages/tidb-dashboard-for-op/src/client/index.tsx
@@ -7,8 +7,7 @@ import * as singleSpa from 'single-spa'
 import { routing, i18n } from '@pingcap/tidb-dashboard-lib'
 import {
   Configuration,
-  DefaultApi as DashboardApi,
-  StatementApi
+  DefaultApi as DashboardApi
 } from '@pingcap/tidb-dashboard-client'
 
 import auth from '~/uilts/auth'
@@ -23,7 +22,7 @@ export * from '@pingcap/tidb-dashboard-client'
 const client = {
   _init(
     apiBasePath: string,
-    apiInstance: DashboardApi & StatementApi,
+    apiInstance: DashboardApi,
     axiosInstance: AxiosInstance
   ) {
     this.apiBasePath = apiBasePath
@@ -31,7 +30,7 @@ const client = {
     this.axiosInstance = axiosInstance
   },
 
-  getInstance(): DashboardApi & StatementApi {
+  getInstance(): DashboardApi {
     return this.apiInstance
   },
 

--- a/ui/packages/tidb-dashboard-for-op/src/client/index.tsx
+++ b/ui/packages/tidb-dashboard-for-op/src/client/index.tsx
@@ -7,7 +7,8 @@ import * as singleSpa from 'single-spa'
 import { routing, i18n } from '@pingcap/tidb-dashboard-lib'
 import {
   Configuration,
-  DefaultApi as DashboardApi
+  DefaultApi as DashboardApi,
+  StatementApi
 } from '@pingcap/tidb-dashboard-client'
 
 import auth from '~/uilts/auth'
@@ -22,7 +23,7 @@ export * from '@pingcap/tidb-dashboard-client'
 const client = {
   _init(
     apiBasePath: string,
-    apiInstance: DashboardApi,
+    apiInstance: DashboardApi & StatementApi,
     axiosInstance: AxiosInstance
   ) {
     this.apiBasePath = apiBasePath
@@ -30,7 +31,7 @@ const client = {
     this.axiosInstance = axiosInstance
   },
 
-  getInstance(): DashboardApi {
+  getInstance(): DashboardApi & StatementApi {
     return this.apiInstance
   },
 

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/context/index.ts
@@ -69,12 +69,22 @@ export interface IStatementDataSource extends ISlowQueryDataSource {
     options?: ReqConfig
   ): AxiosPromise<Array<StatementTimeRange>>
 
-  statementsPlanBindInfoGet(
-    digest: string,
+  statementsPlanBindStatusGet?(
+    sqlDigest: string,
     beginTime: number,
     endTime: number,
     options?: ReqConfig
-  ): AxiosPromise<Array<StatementBinding>>
+  ): AxiosPromise<StatementBinding>
+
+  statementsPlanBindCreate?(
+    planDigest: string,
+    options?: ReqConfig
+  ): AxiosPromise<string>
+
+  statementsPlanBindDelete?(
+    sqlDigest: string,
+    options?: ReqConfig
+  ): AxiosPromise<string>
 }
 
 export interface IStatementContext {
@@ -82,6 +92,7 @@ export interface IStatementContext {
   cfg: IContextConfig & {
     enableExport: boolean
     showHelp?: boolean
+    enablePlanBinding?: boolean
   }
 }
 

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/context/index.ts
@@ -5,7 +5,8 @@ import { AxiosPromise } from 'axios'
 import {
   StatementEditableConfig,
   StatementGetStatementsRequest,
-  StatementModel
+  StatementModel,
+  StatementBinding
 } from '@lib/client'
 
 import { IContextConfig, ReqConfig } from '@lib/types'
@@ -67,6 +68,13 @@ export interface IStatementDataSource extends ISlowQueryDataSource {
   statementsTimeRangesGet(
     options?: ReqConfig
   ): AxiosPromise<Array<StatementTimeRange>>
+
+  statementsPlanBindInfoGet(
+    digest: string,
+    beginTime: number,
+    endTime: number,
+    options?: ReqConfig
+  ): AxiosPromise<Array<StatementBinding>>
 }
 
 export interface IStatementContext {

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.module.less
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.module.less
@@ -1,0 +1,29 @@
+.GreenDot {
+  background-color: #0bc40b;
+  height: 8px;
+  width: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.GreyDot {
+  background-color: #c3c3c3;
+  height: 8px;
+  width: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.PreBlock {
+  background: #f1f1f1;
+  padding: 10px;
+}
+
+.SmallFont {
+  font-size: 13px;
+  font-weight: normal;
+}
+
+.Center {
+  text-align: center;
+}

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
@@ -267,7 +267,6 @@ const PlanTable = ({
   )
 
   useEffect(() => {
-    boundPlanDigest = boundPlanDigest
     if (boundPlanDigest && plans.length > 0) {
       const selectedPlanIndex = plans.findIndex(
         (v) => v.plan_digest === boundPlanDigest
@@ -278,6 +277,7 @@ const PlanTable = ({
       selection.current.setAllSelected(false)
     }
   }, [boundPlanDigest])
+
   return (
     <CardTable
       cardNoMarginTop
@@ -288,7 +288,9 @@ const PlanTable = ({
       checkboxVisibility={CheckboxVisibility.always}
       selection={selection.current}
       selectionPreservedOnEmptyClick
-      onRenderCheckbox={(props) => <Radio checked={props?.checked} />}
+      onRenderCheckbox={(props) => (
+        <Radio checked={props?.checked} disabled={!!boundPlanDigest} />
+      )}
     />
   )
 }

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const PlanBind = () => {
+  return <>plan bind</>
+}
+
+export default PlanBind

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
@@ -154,6 +154,7 @@ const PlanBindModal = ({
           )}
         </div>
       }
+      destroyOnClose
     >
       <ModalContent
         boundPlanDigets={boundPlanDigets}
@@ -181,26 +182,25 @@ const ModalContent = ({
   const planColumns = useMemo(() => genPlanColumns(plans || []), [plans])
   const selection = useRef(
     new Selection({
-      // canSelectItem: (item) => {
-      //   console.log('use ref item', item)
-      //   const digest = (item as StatementModel).plan_digest
-      //   return !boundPlanDigets
-      //     ? true
-      //     : digest === boundPlanDigets
-      //     ? true
-      //     : false
-      // },
+      canSelectItem: (item) => {
+        const digest = (item as StatementModel).plan_digest
+        return !boundPlanDigets
+          ? true
+          : digest === boundPlanDigets
+          ? true
+          : false
+      },
       onSelectionChanged: () => {
         const s = selection.current.getSelection() as StatementModel[]
         onHandleSelectedPlanChange(s)
-        // if (!boundPlanDigets) return
-        // const selectedPlanIndex = plans.findIndex(
-        //   (v) => v.plan_digest === boundPlanDigets
-        // )
+        if (!boundPlanDigets) return
+        const selectedPlanIndex = plans.findIndex(
+          (v) => v.plan_digest === boundPlanDigets
+        )
 
-        // if (s.length === 0) {
-        //   selection.current.setIndexSelected(selectedPlanIndex, true, true)
-        // }
+        if (s.length === 0) {
+          selection.current.setIndexSelected(selectedPlanIndex, true, true)
+        }
       }
     })
   )
@@ -208,11 +208,17 @@ const ModalContent = ({
   useEffect(() => {
     console.log('useEffect boundPlanDigets', boundPlanDigets)
     if (boundPlanDigets && plans.length > 0) {
+      // selection.current.canSelectItem = (item) => {
+      //   const digest = (item as StatementModel).plan_digest
+      //   return digest === boundPlanDigets ? true : false
+      // }
       const selectedPlanIndex = plans.findIndex(
         (v) => v.plan_digest === boundPlanDigets
       )
 
       selection.current.setIndexSelected(selectedPlanIndex, true, true)
+    } else if (!boundPlanDigets) {
+      selection.current.setAllSelected(false)
     }
   }, [boundPlanDigets])
 

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useMemo, useRef, useEffect } from 'react'
-import { Space, Button, Modal, Tooltip, Radio } from 'antd'
+import { Space, Button, Modal, Tooltip, Radio, Alert } from 'antd'
 import { InfoCircleOutlined } from '@ant-design/icons'
 
 import { useClientRequest } from '@lib/utils/useClientRequest'
@@ -61,31 +61,35 @@ const PlanBind = ({ query, plans }: PlanBindProps) => {
 
   return (
     <Space align="center">
-      {boundPlanDigest ? (
-        <Space>
-          <span className={styles.GreenDot} />
-          {t('statement.pages.detail.plan_bind.bound')}
-        </Space>
+      {!hasPlanToBind ? (
+        <Tooltip
+          title={t('statement.pages.detail.plan_bind.bound_available_tooltip')}
+          placement="leftTop"
+        >
+          <InfoCircleOutlined /> Unavailable
+        </Tooltip>
       ) : (
-        <Space>
-          <span className={styles.GreyDot} />
-          {t('statement.pages.detail.plan_bind.not_bound')}
-        </Space>
+        <>
+          {boundPlanDigest ? (
+            <Space>
+              <span className={styles.GreenDot} />
+              {t('statement.pages.detail.plan_bind.bound')}
+            </Space>
+          ) : (
+            <Space>
+              <span className={styles.GreyDot} />
+              {t('statement.pages.detail.plan_bind.not_bound')}
+            </Space>
+          )}
+        </>
       )}
+
       <Button
         onClick={() => handleModalVisibility(true)}
         disabled={!hasPlanToBind}
       >
         {t('statement.pages.detail.plan_bind.title')}
       </Button>
-      {!hasPlanToBind && (
-        <Tooltip
-          title={t('statement.pages.detail.plan_bind.bound_available_tooltip')}
-          placement="rightTop"
-        >
-          <InfoCircleOutlined />
-        </Tooltip>
-      )}
       <PlanBindModal
         showPlanBindModal={showPlanBindModal}
         boundPlanDigest={boundPlanDigest}
@@ -177,9 +181,11 @@ const PlanBindModal = ({
               </Space>
             )}
           </Space>
-          <span className={`${styles.SmallFont}`}>
-            {t('statement.pages.detail.plan_bind.notice')}
-          </span>
+          <Alert
+            type="warning"
+            message={t('statement.pages.detail.plan_bind.notice')}
+            className={`${styles.SmallFont}`}
+          />
         </Space>
       }
       onCancel={handleOnCancel}
@@ -271,7 +277,6 @@ const PlanTable = ({
       const selectedPlanIndex = plans.findIndex(
         (v) => v.plan_digest === boundPlanDigest
       )
-
       selection.current.setIndexSelected(selectedPlanIndex, true, true)
     } else if (!boundPlanDigest) {
       selection.current.setAllSelected(false)

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useMemo, useRef, useEffect } from 'react'
-import { Space, Button, Modal, Tooltip } from 'antd'
+import { Space, Button, Modal, Tooltip, Radio } from 'antd'
 import { InfoCircleOutlined } from '@ant-design/icons'
 
 import { useClientRequest } from '@lib/utils/useClientRequest'
@@ -288,6 +288,7 @@ const PlanTable = ({
       checkboxVisibility={CheckboxVisibility.always}
       selection={selection.current}
       selectionPreservedOnEmptyClick
+      onRenderCheckbox={(props) => <Radio checked={props?.checked} />}
     />
   )
 }

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
@@ -1,7 +1,244 @@
-import React from 'react'
+import React, { useContext, useState, useMemo, useRef, useEffect } from 'react'
+import { Space, Button, Modal } from 'antd'
 
-const PlanBind = () => {
-  return <>plan bind</>
+import { useClientRequest } from '@lib/utils/useClientRequest'
+import { StatementModel } from '@lib/client'
+import { IPageQuery } from '.'
+import { StatementContext } from '../../context'
+import { CardTable } from '@lib/components'
+import { planColumns as genPlanColumns } from '../../utils/tableColumns'
+import {
+  SelectionMode,
+  CheckboxVisibility
+} from 'office-ui-fabric-react/lib/DetailsList'
+import { Selection } from 'office-ui-fabric-react/lib/Selection'
+
+interface PlanBindProps {
+  query: IPageQuery
+  plans: StatementModel[]
+}
+
+const PlanBind = ({ query, plans }: PlanBindProps) => {
+  const ctx = useContext(StatementContext)
+  const { data: planBindingStatus } = useClientRequest((reqConfig) =>
+    ctx!.ds.statementsPlanBindStatusGet!(
+      query.digest!,
+      query.beginTime!,
+      query.endTime!,
+      reqConfig
+    )
+  )
+
+  const [boundPlanDigets, setBoundPlanDigets] = useState<string | null>(null)
+  const [showPlanBindModal, setShowPlanBindModal] = useState(false)
+
+  const handleModalVisibility = (visibility: boolean) => {
+    setShowPlanBindModal(visibility)
+  }
+
+  const handleSetBoundPlanDigets = (planDigest: string | null) => {
+    setBoundPlanDigets(planDigest)
+  }
+
+  useEffect(() => {
+    if (planBindingStatus) {
+      setBoundPlanDigets(planBindingStatus.plan_digest!)
+    }
+  }, [planBindingStatus])
+
+  return (
+    <Space align="center">
+      {boundPlanDigets ? 'Bound' : 'Not Bound'}
+      <Button onClick={() => handleModalVisibility(true)}>Plan Binding</Button>
+      <PlanBindModal
+        showPlanBindModal={showPlanBindModal}
+        boundPlanDigets={boundPlanDigets}
+        plans={plans}
+        sqlDigest={query.digest!}
+        onHandleModalVisibility={handleModalVisibility}
+        onHandleSetBoundPlanDigets={handleSetBoundPlanDigets}
+      />
+    </Space>
+  )
+}
+
+interface PlanBindModalProps {
+  showPlanBindModal: boolean
+  boundPlanDigets: string | null
+  plans: StatementModel[]
+  sqlDigest: string
+  onHandleModalVisibility: (visibility: boolean) => void
+  onHandleSetBoundPlanDigets: (planDigest: string | null) => void
+}
+
+const PlanBindModal = ({
+  showPlanBindModal,
+  boundPlanDigets,
+  plans,
+  sqlDigest,
+  onHandleModalVisibility,
+  onHandleSetBoundPlanDigets
+}: PlanBindModalProps) => {
+  const ctx = useContext(StatementContext)
+  const handleOnCancel = () => {
+    onHandleModalVisibility(false)
+  }
+  const [selectedPlan, setSelectedPlan] = useState<string | null>(null)
+  const [isBinding, setIsBinding] = useState(false)
+  const [isDropping, setIsDropping] = useState(false)
+
+  const handlePlanBind = async () => {
+    setIsBinding(true)
+    try {
+      const res = await ctx!.ds.statementsPlanBindCreate!(selectedPlan!)
+      if (res.data === 'success') {
+        onHandleSetBoundPlanDigets(selectedPlan!)
+      }
+    } catch (error) {
+      console.log(error)
+    } finally {
+      setIsBinding(false)
+    }
+  }
+
+  const handleDropPlan = async () => {
+    setIsDropping(true)
+    try {
+      const res = await ctx!.ds.statementsPlanBindDelete!(sqlDigest)
+      if (res.data === 'success') {
+        setSelectedPlan(null)
+        onHandleSetBoundPlanDigets(null)
+        console.log('drop plan success')
+      }
+    } catch (error) {
+      console.log(error)
+    } finally {
+      setIsDropping(false)
+    }
+  }
+
+  const handleSelectedPlanChange = (plan: StatementModel[] | []) => {
+    if (plan.length === 0) return setSelectedPlan(null)
+    return setSelectedPlan(plan[0].plan_digest!)
+  }
+
+  return (
+    <Modal
+      visible={showPlanBindModal}
+      title={
+        <Space>
+          <span>Plan Bind Modal</span>
+          <span>{boundPlanDigets ? 'Bound' : 'Not Bound'}</span>{' '}
+        </Space>
+      }
+      onCancel={handleOnCancel}
+      width={1000}
+      footer={
+        <div style={{ textAlign: 'center' }}>
+          {boundPlanDigets ? (
+            <Button
+              onClick={handleDropPlan}
+              loading={isDropping}
+              disabled={isDropping}
+            >
+              {isDropping ? 'Dropping...' : 'Drop'}
+            </Button>
+          ) : (
+            <Button
+              onClick={handlePlanBind}
+              loading={isBinding}
+              disabled={isBinding || !selectedPlan}
+            >
+              {isBinding ? 'Binding...' : 'Bind'}
+            </Button>
+          )}
+        </div>
+      }
+    >
+      <ModalContent
+        boundPlanDigets={boundPlanDigets}
+        plans={plans}
+        sqlDigest={sqlDigest}
+        onHandleSelectedPlanChange={handleSelectedPlanChange}
+      />
+    </Modal>
+  )
+}
+
+interface ModalContentProps {
+  boundPlanDigets: string | null
+  plans: StatementModel[]
+  sqlDigest: string
+  onHandleSelectedPlanChange: (plan: StatementModel[] | []) => void
+}
+
+const ModalContent = ({
+  boundPlanDigets,
+  plans,
+  sqlDigest,
+  onHandleSelectedPlanChange
+}: ModalContentProps) => {
+  const planColumns = useMemo(() => genPlanColumns(plans || []), [plans])
+  const selection = useRef(
+    new Selection({
+      // canSelectItem: (item) => {
+      //   console.log('use ref item', item)
+      //   const digest = (item as StatementModel).plan_digest
+      //   return !boundPlanDigets
+      //     ? true
+      //     : digest === boundPlanDigets
+      //     ? true
+      //     : false
+      // },
+      onSelectionChanged: () => {
+        const s = selection.current.getSelection() as StatementModel[]
+        onHandleSelectedPlanChange(s)
+        // if (!boundPlanDigets) return
+        // const selectedPlanIndex = plans.findIndex(
+        //   (v) => v.plan_digest === boundPlanDigets
+        // )
+
+        // if (s.length === 0) {
+        //   selection.current.setIndexSelected(selectedPlanIndex, true, true)
+        // }
+      }
+    })
+  )
+
+  useEffect(() => {
+    console.log('useEffect boundPlanDigets', boundPlanDigets)
+    if (boundPlanDigets && plans.length > 0) {
+      const selectedPlanIndex = plans.findIndex(
+        (v) => v.plan_digest === boundPlanDigets
+      )
+
+      selection.current.setIndexSelected(selectedPlanIndex, true, true)
+    }
+  }, [boundPlanDigets])
+
+  return (
+    <>
+      <p>
+        Notice: This feature does not work for queries with subqueries, queries
+        that access TiFlash, or queries that join 3 or more tables.
+      </p>
+      <p>Bind this SQL</p>
+      <pre style={{ background: '#f1f1f1', padding: '10px' }}>{sqlDigest}</pre>
+      <p>to a special plan</p>
+      {plans && plans.length > 0 && (
+        <CardTable
+          cardNoMarginTop
+          cardNoMarginBottom
+          columns={planColumns}
+          items={plans}
+          selectionMode={SelectionMode.single}
+          checkboxVisibility={CheckboxVisibility.always}
+          selection={selection.current}
+          selectionPreservedOnEmptyClick
+        />
+      )}
+    </>
+  )
 }
 
 export default PlanBind

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
@@ -6,6 +6,7 @@ import { StatementModel } from '@lib/client'
 import { IPageQuery } from '.'
 import { StatementContext } from '../../context'
 import { CardTable } from '@lib/components'
+import styles from './PlanBind.module.less'
 import { planColumns as genPlanColumns } from '../../utils/tableColumns'
 import {
   SelectionMode,
@@ -48,7 +49,17 @@ const PlanBind = ({ query, plans }: PlanBindProps) => {
 
   return (
     <Space align="center">
-      {boundPlanDigest ? 'Bound' : 'Not Bound'}
+      {boundPlanDigest ? (
+        <Space>
+          <span className={styles.GreenDot} />
+          Bound
+        </Space>
+      ) : (
+        <Space>
+          <span className={styles.GreyDot} />
+          Not Bound
+        </Space>
+      )}
       <Button onClick={() => handleModalVisibility(true)}>Plan Binding</Button>
       <PlanBindModal
         showPlanBindModal={showPlanBindModal}
@@ -108,7 +119,6 @@ const PlanBindModal = ({
       if (res.data === 'success') {
         setSelectedPlan(null)
         onHandleSetBoundPlanDigets(null)
-        console.log('drop plan success')
       }
     } catch (error) {
       console.log(error)
@@ -126,23 +136,42 @@ const PlanBindModal = ({
     <Modal
       visible={showPlanBindModal}
       title={
-        <Space>
-          <span>Plan Bind Modal</span>
-          <span>{boundPlanDigest ? 'Bound' : 'Not Bound'}</span>{' '}
+        <Space direction="vertical">
+          <Space size={10}>
+            Plan Binding{' '}
+            {boundPlanDigest ? (
+              <Space className={`${styles.SmallFont}`}>
+                <span className={styles.GreenDot} />
+                Bound
+              </Space>
+            ) : (
+              <Space className={`${styles.SmallFont}`}>
+                <span className={styles.GreyDot} />
+                Not Bound
+              </Space>
+            )}
+          </Space>
+          <span className={`${styles.SmallFont}`}>
+            Notice: This feature does not work for queries with subqueries,
+            queries that access TiFlash, or queries that join 3 or more tables.
+          </span>
         </Space>
       }
       onCancel={handleOnCancel}
       width={1000}
       footer={
-        <div style={{ textAlign: 'center' }}>
+        <div className={styles.Center}>
           {boundPlanDigest ? (
-            <Button
-              onClick={handleDropPlan}
-              loading={isDropping}
-              disabled={isDropping}
-            >
-              {isDropping ? 'Dropping...' : 'Drop'}
-            </Button>
+            <Space direction="vertical">
+              The plan is bound on this SQL.
+              <Button
+                onClick={handleDropPlan}
+                loading={isDropping}
+                disabled={isDropping}
+              >
+                {isDropping ? 'Dropping...' : 'Drop'}
+              </Button>
+            </Space>
           ) : (
             <Button
               onClick={handlePlanBind}
@@ -187,12 +216,10 @@ const ModalContent = ({
 }: ModalContentProps) => {
   return (
     <>
-      <p>
-        Notice: This feature does not work for queries with subqueries, queries
-        that access TiFlash, or queries that join 3 or more tables.
-      </p>
       <p>Bind this SQL</p>
-      <pre style={{ background: '#f1f1f1', padding: '10px' }}>{sqlDigest}</pre>
+      <pre className={`${styles.PreBlock} ${styles.SmallFont}`}>
+        {sqlDigest}
+      </pre>
       <p>to a special plan</p>
       {!isBinding && !isDropping && (
         <PlanTable

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanBind.tsx
@@ -37,14 +37,6 @@ const PlanBind = ({ query, plans }: PlanBindProps) => {
   const [boundPlanDigest, setBoundPlanDigest] = useState<string | null>(null)
   const [showPlanBindModal, setShowPlanBindModal] = useState(false)
 
-  const handleModalVisibility = (visibility: boolean) => {
-    setShowPlanBindModal(visibility)
-  }
-
-  const handleSetBoundPlanDigets = (planDigest: string | null) => {
-    setBoundPlanDigest(planDigest)
-  }
-
   useEffect(() => {
     if (planBindingStatus) {
       setBoundPlanDigest(planBindingStatus.plan_digest!)
@@ -85,7 +77,7 @@ const PlanBind = ({ query, plans }: PlanBindProps) => {
       )}
 
       <Button
-        onClick={() => handleModalVisibility(true)}
+        onClick={() => setShowPlanBindModal(true)}
         disabled={!hasPlanToBind}
       >
         {t('statement.pages.detail.plan_bind.title')}
@@ -95,8 +87,8 @@ const PlanBind = ({ query, plans }: PlanBindProps) => {
         boundPlanDigest={boundPlanDigest}
         plans={plans}
         sqlDigest={query.digest!}
-        onHandleModalVisibility={handleModalVisibility}
-        onHandleSetBoundPlanDigets={handleSetBoundPlanDigets}
+        onHandleModalVisibility={setShowPlanBindModal}
+        onHandleSetBoundPlanDigets={setBoundPlanDigest}
       />
     </Space>
   )
@@ -121,15 +113,12 @@ const PlanBindModal = ({
 }: PlanBindModalProps) => {
   const ctx = useContext(StatementContext)
   const { t } = useTranslation()
-  const handleOnCancel = () => {
-    onHandleModalVisibility(false)
-  }
+
   const [selectedPlan, setSelectedPlan] = useState<string | null>(null)
-  const [isBinding, setIsBinding] = useState(false)
-  const [isDropping, setIsDropping] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
 
   const handlePlanBind = async () => {
-    setIsBinding(true)
+    setIsLoading(true)
     try {
       const res = await ctx!.ds.statementsPlanBindCreate!(selectedPlan!)
       if (res.data === 'success') {
@@ -138,12 +127,12 @@ const PlanBindModal = ({
     } catch (error) {
       console.log(error)
     } finally {
-      setIsBinding(false)
+      setIsLoading(false)
     }
   }
 
   const handleDropPlan = async () => {
-    setIsDropping(true)
+    setIsLoading(true)
     try {
       const res = await ctx!.ds.statementsPlanBindDelete!(sqlDigest)
       if (res.data === 'success') {
@@ -153,7 +142,7 @@ const PlanBindModal = ({
     } catch (error) {
       console.log(error)
     } finally {
-      setIsDropping(false)
+      setIsLoading(false)
     }
   }
 
@@ -188,7 +177,7 @@ const PlanBindModal = ({
           />
         </Space>
       }
-      onCancel={handleOnCancel}
+      onCancel={() => onHandleModalVisibility(false)}
       width={1000}
       footer={
         <div className={styles.Center}>
@@ -197,8 +186,8 @@ const PlanBindModal = ({
               {t('statement.pages.detail.plan_bind.bound_status_desc')}
               <Button
                 onClick={handleDropPlan}
-                loading={isDropping}
-                disabled={isDropping}
+                loading={isLoading}
+                disabled={isLoading}
               >
                 {t('statement.pages.detail.plan_bind.drop_btn_txt')}
               </Button>
@@ -206,8 +195,8 @@ const PlanBindModal = ({
           ) : (
             <Button
               onClick={handlePlanBind}
-              loading={isBinding}
-              disabled={isBinding || !selectedPlan}
+              loading={isLoading}
+              disabled={isLoading || !selectedPlan}
             >
               {t('statement.pages.detail.plan_bind.bind_btn_txt')}
             </Button>
@@ -221,7 +210,7 @@ const PlanBindModal = ({
         {sqlDigest}
       </pre>
       <p>{t('statement.pages.detail.plan_bind.to_plan')}</p>
-      {!isBinding && !isDropping && (
+      {!isLoading && (
         <PlanTable
           plans={plans}
           boundPlanDigest={boundPlanDigest}

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/index.tsx
@@ -39,6 +39,16 @@ export interface IPageQuery {
 
 const STMT_DETAIL_EXPAND = 'statement.detail_expand'
 
+// sort plans by plan_count first,
+// if plan_count is the same, sort plans by ava_latency
+const compareFn = (a: StatementModel, b: StatementModel) => {
+  if (a.exec_count! === b.exec_count!) {
+    return b.avg_latency! - a.avg_latency!
+  }
+
+  return b.exec_count! - a.exec_count!
+}
+
 function DetailPage() {
   const ctx = useContext(StatementContext)
 
@@ -78,6 +88,7 @@ function DetailPage() {
   useEffect(() => {
     if (plans && plans.length > 0) {
       selection.current.setAllSelected(true)
+      plans.sort(compareFn)
     }
   }, [plans])
 
@@ -194,6 +205,7 @@ function DetailPage() {
                   cardNoMargin
                   columns={planColumns}
                   items={plans}
+                  orderBy="exec_count"
                   selectionMode={SelectionMode.multiple}
                   selection={selection.current}
                   selectionPreservedOnEmptyClick

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/index.tsx
@@ -56,17 +56,6 @@ function DetailPage() {
     )
   )
 
-  const { data } = useClientRequest((reqConfig) =>
-    ctx!.ds.statementsPlanBindInfoGet(
-      query.digest!,
-      query.beginTime!,
-      query.endTime!,
-      reqConfig
-    )
-  )
-
-  console.log('data', data)
-
   const { t } = useTranslation()
   const planColumns = useMemo(() => genPlanColumns(plans || []), [plans])
 
@@ -79,7 +68,6 @@ function DetailPage() {
       }
     })
   )
-
   const [sqlExpanded, setSqlExpanded] = useVersionedLocalStorageState(
     STMT_DETAIL_EXPAND,
     { defaultValue: false }
@@ -101,7 +89,11 @@ function DetailPage() {
             <ArrowLeftOutlined /> {t('statement.pages.detail.head.back')}
           </Link>
         }
-        titleExtra={<>title Extra</>}
+        titleExtra={
+          ctx?.cfg.enablePlanBinding && plans && plans.length > 0 ? (
+            <PlanBind query={query} plans={plans!} />
+          ) : null
+        }
       >
         <AnimatedSkeleton showSkeleton={isLoading}>
           {error && <ErrorBar errors={[error]} />}
@@ -196,7 +188,7 @@ function DetailPage() {
                   cardNoMargin
                   columns={planColumns}
                   items={plans}
-                  selectionMode={SelectionMode.single}
+                  selectionMode={SelectionMode.multiple}
                   selection={selection.current}
                   selectionPreservedOnEmptyClick
                 />

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/index.tsx
@@ -26,6 +26,7 @@ import { useVersionedLocalStorageState } from '@lib/utils/useVersionedLocalStora
 
 import { planColumns as genPlanColumns } from '../../utils/tableColumns'
 import PlanDetail from './PlanDetail'
+import PlanBind from './PlanBind'
 import { StatementContext } from '../../context'
 
 export interface IPageQuery {
@@ -54,6 +55,18 @@ function DetailPage() {
       reqConfig
     )
   )
+
+  const { data } = useClientRequest((reqConfig) =>
+    ctx!.ds.statementsPlanBindInfoGet(
+      query.digest!,
+      query.beginTime!,
+      query.endTime!,
+      reqConfig
+    )
+  )
+
+  console.log('data', data)
+
   const { t } = useTranslation()
   const planColumns = useMemo(() => genPlanColumns(plans || []), [plans])
 
@@ -88,6 +101,7 @@ function DetailPage() {
             <ArrowLeftOutlined /> {t('statement.pages.detail.head.back')}
           </Link>
         }
+        titleExtra={<>title Extra</>}
       >
         <AnimatedSkeleton showSkeleton={isLoading}>
           {error && <ErrorBar errors={[error]} />}
@@ -182,7 +196,7 @@ function DetailPage() {
                   cardNoMargin
                   columns={planColumns}
                   items={plans}
-                  selectionMode={SelectionMode.multiple}
+                  selectionMode={SelectionMode.single}
                   selection={selection.current}
                   selectionPreservedOnEmptyClick
                 />

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/index.tsx
@@ -5,6 +5,7 @@ import React, { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useLocation } from 'react-router-dom'
 import { ArrowLeftOutlined } from '@ant-design/icons'
+import { useIsFeatureSupport } from '@lib/utils/store'
 
 import { StatementModel } from '@lib/client'
 import {
@@ -80,6 +81,8 @@ function DetailPage() {
     }
   }, [plans])
 
+  const supportPlanBinding = useIsFeatureSupport('plan_binding')
+
   return (
     <div>
       <Head
@@ -90,7 +93,10 @@ function DetailPage() {
           </Link>
         }
         titleExtra={
-          ctx?.cfg.enablePlanBinding && plans && plans.length > 0 ? (
+          ctx?.cfg.enablePlanBinding &&
+          supportPlanBinding &&
+          plans &&
+          plans.length > 0 ? (
             <PlanBind query={query} plans={plans!} />
           ) : null
         }

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/en.yaml
@@ -9,7 +9,7 @@ statement:
         title: Plan Binding
         bound: Bound
         not_bound: Not Bound
-        bound_available_tooltip: Cannot bind plan since this SQL has not execution plan
+        bound_available_tooltip: 'Plan Binding only supported bindable SQL statements including SELECT, DELETE, UPDATE, and INSERT / REPLACE with SELECT subqueries.'
         notice: 'Notice: This feature does not work for queries with subqueries, queries that access TiFlash, or queries that join 3 or more tables.'
         bound_sql: 'Bind this SQL'
         to_plan: 'to a special plan'

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/en.yaml
@@ -5,6 +5,17 @@ statement:
       head:
         back: List
         title: Statement Information
+      plan_bind:
+        title: Plan Binding
+        bound: Bound
+        not_bound: Not Bound
+        bound_available_tooltip: Cannot bind plan since this SQL has not execution plan
+        notice: 'Notice: This feature does not work for queries with subqueries, queries that access TiFlash, or queries that join 3 or more tables.'
+        bound_sql: 'Bind this SQL'
+        to_plan: 'to a special plan'
+        bound_status_desc: The plan has bound to this SQL
+        drop_btn_txt: Drop
+        bind_btn_txt: Bind
       desc:
         time_range: Time Range
         plans:

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
@@ -6,7 +6,7 @@ statement:
         back: 返回列表
         title: SQL 语句信息
       plan_bind:
-        title: 绑定执行计划
+        title: 执行计划绑定
         bound: 已绑定
         not_bound: 未绑定
         bound_available_tooltip: 该 SQL 没有执行计划，无法绑定

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
@@ -9,7 +9,7 @@ statement:
         title: 执行计划绑定
         bound: 已绑定
         not_bound: 未绑定
-        bound_available_tooltip: 该 SQL 没有执行计划，无法绑定
+        bound_available_tooltip: 计划绑定仅支持可绑定的 SQL 语句，包括 SELECT、DELETE、UPDATE 和 INSERT / REPLACE with SELECT 子查询。
         notice: '注意: 此功能不适用于带有子查询的查询、访问 TiFlash 的查询或连接 3 个或更多表的查询。'
         bound_sql: '绑定这条 SQL'
         to_plan: '到执行计划'

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
@@ -5,6 +5,17 @@ statement:
       head:
         back: 返回列表
         title: SQL 语句信息
+      plan_bind:
+        title: 绑定执行计划
+        bound: 已绑定
+        not_bound: 未绑定
+        bound_available_tooltip: 该 SQL 没有执行计划，无法绑定
+        notice: '注意: 此功能不适用于带有子查询的查询、访问 TiFlash 的查询或连接 3 个或更多表的查询。'
+        bound_sql: '绑定这条 SQL'
+        to_plan: '到执行计划'
+        bound_status_desc: 该 SQL 已绑定执行计划
+        drop_btn_txt: 解绑
+        bind_btn_txt: 绑定
       desc:
         time_range: 时间范围
         plans:


### PR DESCRIPTION
## what this PR did?
- show plan bind status on statement detail page.
- provide a `Plan Binding` button on statement detail page.
- users are able to bind/drop a specific plan on a SQL.

![20230207-100835](https://user-images.githubusercontent.com/34967660/217129759-bf35d84a-421b-4fe9-8b71-341f5d4dc4a2.jpeg)
![20230207-100829](https://user-images.githubusercontent.com/34967660/217129771-cbf3e201-d389-4df8-be4f-46cd70954e99.jpeg)

