### PR TITLE
chore: slow query and statements apps refines

### DIFF
--- a/ui/packages/tidb-dashboard-for-clinic-cloud/package.json
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pingcap/tidb-dashboard-for-clinic-cloud",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "main": "dist/dashboardApp.js",
   "module": "dist/dashboardApp.js",
   "files": [

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/package.json
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pingcap/tidb-dashboard-for-clinic-cloud",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "main": "dist/dashboardApp.js",
   "module": "dist/dashboardApp.js",
   "files": [

--- a/ui/packages/tidb-dashboard-for-op/src/apps/SlowQuery/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/SlowQuery/context.ts
@@ -75,5 +75,9 @@ export const ctx: ISlowQueryContext = {
     enableExport: true,
     showDBFilter: true
     // instantQuery: false,
+    // timeRangeSelector: {
+    //   recentSeconds: [3 * 24 * 60 * 60],
+    //   customAbsoluteRangePicker: true
+    // }
   }
 }

--- a/ui/packages/tidb-dashboard-for-op/src/apps/SlowQuery/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/SlowQuery/context.ts
@@ -74,5 +74,6 @@ export const ctx: ISlowQueryContext = {
     apiPathBase: client.getBasePath(),
     enableExport: true,
     showDBFilter: true
+    // instantQuery: false,
   }
 }

--- a/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
@@ -212,5 +212,6 @@ export const ctx: IStatementContext = {
     apiPathBase: client.getBasePath(),
     enableExport: true,
     enablePlanBinding: true
+    // instantQuery: false
   }
 }

--- a/ui/packages/tidb-dashboard-lib/src/apps/Monitoring/components/Monitoring.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Monitoring/components/Monitoring.tsx
@@ -27,6 +27,7 @@ import { tz } from '@lib/utils'
 import { useTimeRangeValue } from '@lib/components/TimeRangeSelector/hook'
 import { telemetry } from '../utils/telemetry'
 import { MonitoringContext } from '../context'
+// TODO: move to shared folder
 import { LimitTimeRange } from '@lib/apps/Overview/components/LimitTimeRange'
 
 export default function Monitoring() {

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/context/index.ts
@@ -70,6 +70,12 @@ export interface ISlowQueryConfig extends IContextConfig {
   // true means start to search instantly after changing any filter options
   // false means only to start searching after clicking the "Query" button
   instantQuery?: boolean
+
+  // to limit the time range picker range
+  timeRangeSelector?: {
+    recentSeconds: number[]
+    customAbsoluteRangePicker: boolean
+  }
 }
 
 export interface ISlowQueryContext {

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/context/index.ts
@@ -62,7 +62,14 @@ export interface ISlowQueryConfig extends IContextConfig {
   enableExport: boolean
   showDBFilter: boolean
   showHelp?: boolean
-  listApiReturnDetail?: boolean // true means the list api will return all fields value of an item, not just the selected fields
+
+  // true means the list api will return all fields value of an item, not just the selected fields
+  // in this case, the detail page doesn't need to request detail api any more
+  listApiReturnDetail?: boolean
+
+  // true means start to search instantly after changing any filter options
+  // false means only to start searching after clicking the "Query" button
+  instantQuery?: boolean
 }
 
 export interface ISlowQueryContext {

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/index.tsx
@@ -21,7 +21,7 @@ function AppRoutes() {
   return (
     <Routes>
       <Route path="/slow_query" element={<List />} />
-      <Route path="/slow_query/detail" element={<Detail />} />
+      <Route path="/slow_query/detail" element={<Detail historyBack />} />
       <Route path="/slow_query/v2" element={<ListV2 />} />
       <Route path="/slow_query/v2/detail" element={<Detail historyBack />} />
       <Route

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
@@ -144,6 +144,7 @@ function List() {
 
   useDeepCompareChange(() => {
     if (
+      ctx?.cfg.instantQuery === false ||
       controller.isDataLoadedSlowly || // if data was loaded slowly
       controller.isDataLoadedSlowly === null // or a request is not yet finished (which means slow network)..
     ) {

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
@@ -183,7 +183,7 @@ function List() {
 
   return (
     <div className={styles.list_container}>
-      <Card>
+      <Card noMarginBottom>
         <Toolbar className={styles.list_toolbar} data-e2e="slow_query_toolbar">
           <Space>
             <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
@@ -270,6 +270,8 @@ function List() {
           </Space>
         </Toolbar>
       </Card>
+
+      <div style={{ height: 16 }} />
 
       {controller.data?.length === 0 ? (
         <Result title={t('slow_query.overview.empty_result')} />

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
@@ -290,7 +290,7 @@ function List() {
       ) : (
         <div style={{ height: '100%', position: 'relative' }}>
           <ScrollablePane>
-            {controller.isDataLoadedSlowly && (
+            {controller.isDataLoadedSlowly && (ctx?.cfg.instantQuery ?? true) && (
               <Card noMarginBottom noMarginTop>
                 <Alert
                   message={t('slow_query.overview.slow_load_info')}

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
@@ -78,8 +78,6 @@ function List() {
       visibleColumnKeys
     },
 
-    persistQueryInSession: false,
-
     ds: ctx!.ds
   })
 

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
@@ -42,6 +42,7 @@ import { useDebounceFn, useMemoizedFn } from 'ahooks'
 import { useDeepCompareChange } from '@lib/utils/useChange'
 import { isDistro } from '@lib/utils/distro'
 import { SlowQueryContext } from '../../context'
+import { LimitTimeRange } from '@lib/apps/Overview/components/LimitTimeRange'
 
 const { Option } = Select
 
@@ -187,7 +188,17 @@ function List() {
       <Card noMarginBottom>
         <Toolbar className={styles.list_toolbar} data-e2e="slow_query_toolbar">
           <Space>
-            <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+            {ctx?.cfg.timeRangeSelector !== undefined ? (
+              <LimitTimeRange
+                value={timeRange}
+                onChange={setTimeRange}
+                recent_seconds={ctx.cfg.timeRangeSelector.recentSeconds}
+                customAbsoluteRangePicker={true}
+                onZoomOutClick={() => {}}
+              />
+            ) : (
+              <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+            )}
             {ctx!.cfg.showDBFilter && (
               <MultiSelect.Plain
                 placeholder={t('slow_query.toolbar.schemas.placeholder')}

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/en.yaml
@@ -123,7 +123,7 @@ slow_query:
       error: Failed
   overview:
     empty_result: No matched slow queries
-    result_count: Get {{ n }} results.
+    result_count: '{{ n }} results.'
     slow_load_info: On-the-fly update is disabled due to slow data loading. You can initiate query manually by clicking the "Query" button.
   detail:
     head:

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/zh.yaml
@@ -125,7 +125,7 @@ slow_query:
       error: 失败
   overview:
     empty_result: 没有符合条件的慢查询
-    result_count: 得到 {{ n }} 条结果。
+    result_count: '{{ n }} 条结果。'
     slow_load_info: 数据加载耗时较长，已禁用即时更新。修改查询条件后，您可以手工点击”查询“按钮来发起查询。
   detail:
     head:

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/context/index.ts
@@ -93,6 +93,7 @@ export interface IStatementContext {
     enableExport: boolean
     showHelp?: boolean
     enablePlanBinding?: boolean
+    instantQuery?: boolean
   }
 }
 

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
@@ -168,6 +168,7 @@ export default function StatementsOverview() {
 
   useDeepCompareChange(() => {
     if (
+      ctx?.cfg.instantQuery === false ||
       controller.isDataLoadedSlowly || // if data was loaded slowly
       controller.isDataLoadedSlowly === null // or a request is not yet finished (which means slow network)..
     ) {

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
@@ -344,7 +344,7 @@ export default function StatementsOverview() {
           data-e2e="statements_table"
         >
           <ScrollablePane>
-            {controller.isDataLoadedSlowly && (
+            {controller.isDataLoadedSlowly && (ctx?.cfg.instantQuery ?? true) && (
               <Card noMarginBottom noMarginTop>
                 <Alert
                   message={t('statement.pages.overview.slow_load_info')}

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
@@ -207,7 +207,7 @@ export default function StatementsOverview() {
 
   return (
     <div className={styles.list_container}>
-      <Card>
+      <Card noMarginBottom>
         <Toolbar className={styles.list_toolbar} data-e2e="statement_toolbar">
           <Space>
             <TimeRangeSelector
@@ -334,6 +334,8 @@ export default function StatementsOverview() {
           </Space>
         </Toolbar>
       </Card>
+
+      <div style={{ height: 16 }} />
 
       {controller.isEnabled ? (
         <div

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/en.yaml
@@ -57,7 +57,7 @@ statement:
           custom_time_ranges: Custom
         export: Export
         exporting: Exporting
-      result_count: Get {{ n }} results.
+      result_count: '{{ n }} results.'
       actual_range: 'Due to time window and expiration configurations, currently displaying data in time range: '
       slow_load_info: On-the-fly update is disabled due to slow data loading. You can initiate query manually by clicking the "Query" button.
   settings:

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
@@ -57,7 +57,7 @@ statement:
           custom_time_ranges: 自定义时间范围
         export: 导出
         exporting: 正在导出
-      result_count: 得到 {{ n }} 条结果。
+      result_count: '{{ n }} 条结果。'
       actual_range: 基于设置的时间窗及过期时间，当前显示数据的时间范围：
       slow_load_info: 数据加载耗时较长，已禁用即时更新。修改查询条件后，您可以手工点击”查询“按钮来发起查询。
   settings:


### PR DESCRIPTION
## What Did

1. Make slow query list page remember the filter options again when jumping back from detail page
2. Update wording "Get 24 results" to "24 results"
3. Reduce the spacing between toolbar and result
4. Support config whether do instant query
5. Support to limit the slow query time range picker range

## Preview

![image](https://user-images.githubusercontent.com/1284531/221742881-ef46694a-9323-43d1-8511-559aaaab5223.png)

![image](https://user-images.githubusercontent.com/1284531/221742806-c409190a-8982-400f-885c-c883d1582892.png)


