### PR TITLE
Fixed issue #1505: Wrong disk mount directory of TiFlash

### DIFF
--- a/pkg/apiserver/clusterinfo/hostinfo/cluster_config.go
+++ b/pkg/apiserver/clusterinfo/hostinfo/cluster_config.go
@@ -23,7 +23,8 @@ func FillInstances(db *gorm.DB, m InfoMap) error {
 		Table("INFORMATION_SCHEMA.CLUSTER_CONFIG").
 		Where("(`TYPE` = 'tidb' AND `KEY` = 'log.file.filename') " +
 			"OR (`TYPE` = 'tikv' AND `KEY` = 'storage.data-dir') " +
-			"OR (`TYPE` = 'pd' AND `KEY` = 'data-dir')").
+			"OR (`TYPE` = 'pd' AND `KEY` = 'data-dir') " +
+			"OR (`TYPE` = 'tiflash' AND `KEY` = 'engine-store.path')").
 		Find(&rows).Error; err != nil {
 		return err
 	}


### PR DESCRIPTION
Removed hacking logic for tiflash in FillFromClusterHardwareTable(). Added the same logic for tiflash like pd, tikv and tidb in FillInstances().  