### PR TITLE
distinguish tiflash_compute node

### DIFF
--- a/pkg/utils/topology/store.go
+++ b/pkg/utils/topology/store.go
@@ -27,7 +27,7 @@ func FetchStoreTopology(pdClient *pd.Client) ([]StoreInfo, []StoreInfo, error) {
 	for _, store := range stores {
 		isTiFlash := false
 		for _, label := range store.Labels {
-			if label.Key == "engine" && label.Value == "tiflash" {
+			if label.Key == "engine" && (label.Value == "tiflash" || label.Value == "tiflash_compute") {
 				isTiFlash = true
 			}
 		}


### PR DESCRIPTION
tiflash has three kinds of roles:
1. WriteNode: with label: <engine, tiflash> && <engine_role, write>
2. ComputeNode: with label: <engine, tiflash_compute>
3. Coupled TiFlash: with label <engine, tiflash>

For now, dashboard treat ComputeNode as TiKV, so need to fix.

Before: treat 127.0.0.1:3933 as TiKV
![bc6bc752-1a87-4936-8165-92c82254f75f](https://user-images.githubusercontent.com/7493273/231746513-62c1c3a7-ce26-4b62-8aac-38629b189562.jpeg)

After: 
![74f6ac89-2893-4d30-9627-78c8b9af3a57](https://user-images.githubusercontent.com/7493273/231746599-d20613b7-b84a-4f40-bbdf-ec0df7958e7e.jpeg)
