### PR TITLE
fix: make Resource Manager entry show correctly

### DIFF
--- a/ui/packages/tidb-dashboard-for-op/src/dashboardApp/layout/main/Sider/index.tsx
+++ b/ui/packages/tidb-dashboard-for-op/src/dashboardApp/layout/main/Sider/index.tsx
@@ -143,8 +143,7 @@ function Sider({
   )
 
   const supportTopSQL = useIsFeatureSupport('topsql')
-  // const supportResourceManager = useIsFeatureSupport('resource_manager')
-  const supportResourceManager = true
+  const supportResourceManager = useIsFeatureSupport('resource_manager')
   const menuItems = [
     useAppMenuItem(registry, 'overview'),
     useAppMenuItem(registry, 'cluster_info'),


### PR DESCRIPTION
Now the `Resource Manger` app entry shows for every TiDB version, that's not correct, it should only show for the TiDB version that support resource manger feature, aka >= 7.1.0