### PR TITLE
chore: hide system report for clinic cloud

### DIFF
--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/dashboardApp/layout/main/Sider/index.tsx
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/dashboardApp/layout/main/Sider/index.tsx
@@ -152,7 +152,7 @@ function Sider({
     useAppMenuItem(registry, 'statement'),
     useAppMenuItem(registry, 'slow_query'),
     useAppMenuItem(registry, 'keyviz'),
-    useAppMenuItem(registry, 'system_report'),
+    // useAppMenuItem(registry, 'system_report'),
     // warning: "diagnose" app doesn't release yet
     // useAppMenuItem(registry, 'diagnose'),
     useAppMenuItem(registry, 'monitoring'),


### PR DESCRIPTION
Temporary hide this feature entry because it may cause TiKV / TiFlash crash in some cases, will bring it back after fixing.