### PR TITLE
ci: fix `run_services.sh` for tiup

### DIFF
--- a/scripts/_inc/run_services.sh
+++ b/scripts/_inc/run_services.sh
@@ -28,7 +28,7 @@ stop_tidb() {
 
 ensure_tidb() {
   i=1
-  while ! grep "CLUSTER START SUCCESSFULLY" $INTEGRATION_LOG_PATH; do
+  while ! grep "TiDB Playground Cluster is started" $INTEGRATION_LOG_PATH; do
     i=$((i+1))
     if [ "$i" -gt 60 ]; then
       echo 'Failed to start TiDB'


### PR DESCRIPTION
close #1547
because if this pr https://github.com/pingcap/tiup/pull/2163/files#diff-db646158ed09e3000e878361e90161269ce3141eb9c8311adec4fc32b036dbbeR923 had modified `CLUSTER START SUCCESSFULLY` to `TiDB Cluster is started`

And for master now is `TiDB Playground Cluster is started`
https://github.com/pingcap/tiup/blob/master/components/playground/playground.go#L978