### PR TITLE
feat(conprof): show conprof download link for TiCDC

### DIFF
--- a/pkg/apiserver/conprof/service.go
+++ b/pkg/apiserver/conprof/service.go
@@ -144,6 +144,7 @@ type ComponentNum struct {
 	PD      int `json:"pd"`
 	TiKV    int `json:"tikv"`
 	TiFlash int `json:"tiflash"`
+	TiCDC   int `json:"ticdc"`
 }
 
 type GroupProfiles struct {

--- a/ui/packages/tidb-dashboard-client/src/client/api/models/conprof-component-num.ts
+++ b/ui/packages/tidb-dashboard-client/src/client/api/models/conprof-component-num.ts
@@ -31,6 +31,12 @@ export interface ConprofComponentNum {
      * @type {number}
      * @memberof ConprofComponentNum
      */
+    'ticdc'?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ConprofComponentNum
+     */
     'tidb'?: number;
     /**
      * 

--- a/ui/packages/tidb-dashboard-client/swagger/spec.json
+++ b/ui/packages/tidb-dashboard-client/swagger/spec.json
@@ -3923,6 +3923,9 @@
                 "pd": {
                     "type": "integer"
                 },
+                "ticdc": {
+                    "type": "integer"
+                },
                 "tidb": {
                     "type": "integer"
                 },

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/utils/distro/strings_res.json
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/utils/distro/strings_res.json
@@ -1,1 +1,7 @@
-{ "tidb": "TiDB", "tikv": "TiKV", "pd": "PD", "tiflash": "TiFlash" }
+{
+  "tidb": "TiDB",
+  "tikv": "TiKV",
+  "pd": "PD",
+  "tiflash": "TiFlash",
+  "ticdc": "TiCDC"
+}

--- a/ui/packages/tidb-dashboard-for-op/src/utils/distro/strings_res.json
+++ b/ui/packages/tidb-dashboard-for-op/src/utils/distro/strings_res.json
@@ -1,1 +1,7 @@
-{"tidb":"TiDB","tikv":"TiKV","pd":"PD","tiflash":"TiFlash"}
+{
+  "tidb": "TiDB",
+  "tikv": "TiKV",
+  "pd": "PD",
+  "tiflash": "TiFlash",
+  "ticdc": "TiCDC"
+}

--- a/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/components/DiskTable.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/components/DiskTable.tsx
@@ -41,7 +41,8 @@ function expandDisksItems(rows: HostinfoInfo[]): IExpandedDiskItem[] {
           pd: 0,
           tidb: 0,
           tikv: 0,
-          tiflash: 0
+          tiflash: 0,
+          ticdc: 0
         }
       }
       instancesPerPartition[i.partition_path_lower!][i.type!]++
@@ -72,7 +73,8 @@ function expandDisksItems(rows: HostinfoInfo[]): IExpandedDiskItem[] {
           pd: 0,
           tidb: 0,
           tikv: 0,
-          tiflash: 0
+          tiflash: 0,
+          ticdc: 0
         }
       })
     }

--- a/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/components/HostTable.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/components/HostTable.tsx
@@ -27,7 +27,8 @@ function expandHostItems(rows: HostinfoInfo[]): IExpandedHostItem[] {
       pd: 0,
       tidb: 0,
       tikv: 0,
-      tiflash: 0
+      tiflash: 0,
+      ticdc: 0
     }
 
     Object.values(row.instances ?? {}).forEach((i) => {

--- a/ui/packages/tidb-dashboard-lib/src/apps/ContinuousProfiling/pages/List.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/ContinuousProfiling/pages/List.tsx
@@ -104,16 +104,21 @@ export default function Page() {
       {
         name: t('conprof.list.table.columns.targets'),
         key: 'targets',
-        minWidth: 150,
-        maxWidth: 250,
+        minWidth: 250,
+        maxWidth: 300,
         onRender: (rec) => {
-          const { tikv, tidb, pd, tiflash } = rec.component_num
-          const s = `${tikv} ${instanceKindName(
+          const { tikv, tidb, pd, tiflash, ticdc } = rec.component_num
+          let s = `${tikv} ${instanceKindName(
             'tikv'
           )}, ${tidb} ${instanceKindName('tidb')}, ${pd} ${instanceKindName(
             'pd'
           )}, ${tiflash} ${instanceKindName('tiflash')}`
-          return <span>{s}</span>
+          // to be compatible with old version
+          // this field doesn't not exist in the old version
+          if (ticdc !== undefined) {
+            s = `${s}, ${ticdc} ${instanceKindName('ticdc')}`
+          }
+          return s
         }
       },
       {
@@ -166,8 +171,8 @@ export default function Page() {
       {
         name: t('conprof.list.table.columns.start_at'),
         key: 'ts',
-        minWidth: 160,
-        maxWidth: 220,
+        minWidth: 200,
+        maxWidth: 250,
         onRender: (rec) => {
           return <DateTime.Long unixTimestampMs={rec.ts * 1000} />
         }

--- a/ui/packages/tidb-dashboard-lib/src/client/models.ts
+++ b/ui/packages/tidb-dashboard-lib/src/client/models.ts
@@ -380,6 +380,12 @@ export interface ConprofComponentNum {
      * @type {number}
      * @memberof ConprofComponentNum
      */
+    'ticdc'?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ConprofComponentNum
+     */
     'tidb'?: number;
     /**
      * 

--- a/ui/packages/tidb-dashboard-lib/src/components/InstanceSelect/ValueDisplay.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/components/InstanceSelect/ValueDisplay.tsx
@@ -36,7 +36,8 @@ export default function ValueDisplay({
       pd: newInstanceStat(),
       tidb: newInstanceStat(),
       tikv: newInstanceStat(),
-      tiflash: newInstanceStat()
+      tiflash: newInstanceStat(),
+      ticdc: newInstanceStat()
     }
     items.forEach((item) => {
       instanceStats[item.instanceKind].all++

--- a/ui/packages/tidb-dashboard-lib/src/utils/instanceTable.ts
+++ b/ui/packages/tidb-dashboard-lib/src/utils/instanceTable.ts
@@ -8,9 +8,8 @@ import {
   TopologyStoreInfo
 } from '@lib/client'
 
-export type InstanceKind = 'pd' | 'tidb' | 'tikv' | 'tiflash'
-
-export const InstanceKinds: InstanceKind[] = ['pd', 'tidb', 'tikv', 'tiflash']
+export const InstanceKinds = ['pd', 'tidb', 'tikv', 'tiflash', 'ticdc'] as const
+export type InstanceKind = typeof InstanceKinds[number]
 
 export const InstanceStatus = {
   Unreachable: 0,

--- a/util/distro/distro.go
+++ b/util/distro/distro.go
@@ -22,6 +22,7 @@ type DistributionResource struct {
 	TiKV     string `json:"tikv,omitempty"`
 	PD       string `json:"pd,omitempty"`
 	TiFlash  string `json:"tiflash,omitempty"`
+	TiCDC    string `json:"ticdc,omitempty"`
 }
 
 var defaultDistroRes = DistributionResource{
@@ -30,6 +31,7 @@ var defaultDistroRes = DistributionResource{
 	TiKV:     "TiKV",
 	PD:       "PD",
 	TiFlash:  "TiFlash",
+	TiCDC:    "TiCDC",
 }
 
 var (


### PR DESCRIPTION
## What Did

This PR supports to view TiCDC conprof status.

~~TODO: test compatibility with old versions (7.1, 6.5. 6.1)~~

## Test

Test in 7.3.0, 7.1.0, 6.5.3, 6.1.0.

6.1.0 doesn't show TiCDC component in conprof, because the ngm of this version doesn't support TiCDC.

others all show TiCDC component in conprof.

## Preview

Run dev env:

```
$ tiup playground 
$ tiup cdc server --addr 127.0.0.1:8301
```

The cluster and cdc are both 7.3.0 version.

![image](https://github.com/pingcap/tidb-dashboard/assets/1284531/aa95f0af-b374-424d-be66-5aa2d0be2b05)

![image](https://github.com/pingcap/tidb-dashboard/assets/1284531/8be04f1a-f37c-4d77-bffe-934a05de758e)

**Note:**  in my test environment, the ngm can't get the TiCDC profiles successfully, don't know why, so in the above screenshot, the status is `Partial Finished`, and in the detail page, the status for `TiCDC` is `Error`, clicking the `Error Information`, it will show the error reason in the modal.
