### PR TITLE
hide full stacktrace info in error message

### DIFF
--- a/util/rest/context_helpers.go
+++ b/util/rest/context_helpers.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/joomcode/errorx"
 
 	"github.com/pingcap/tidb-dashboard/util/jsonserde/ginadapter"
 )
@@ -16,7 +15,8 @@ import (
 // Otherwise there will be no error message written to the client.
 // See `ErrorHandlerFn` for more details.
 func Error(c *gin.Context, err error) {
-	_ = c.Error(errorx.EnsureStackTrace(err))
+	// For security reasons, we need to hide detailed stacktrace info.
+	_ = c.Error(err) // before: c.Error(errorx.EnsureStackTrace(err))
 }
 
 // JSON writes a JSON string to the client with the given status code.

--- a/util/rest/error_resp.go
+++ b/util/rest/error_resp.go
@@ -95,9 +95,10 @@ func buildDetailMessage(err error) string {
 
 func NewErrorResponse(err error) ErrorResponse {
 	return ErrorResponse{
-		Error:    true,
-		Message:  buildSimpleMessage(err),
-		Code:     removeErrorPrefix(buildCode(err)),
-		FullText: buildDetailMessage(err),
+		Error:   true,
+		Message: buildSimpleMessage(err),
+		Code:    removeErrorPrefix(buildCode(err)),
+		// For security reasons, we need to hide detailed stacktrace info.
+		// FullText: buildDetailMessage(err),
 	}
 }


### PR DESCRIPTION
We have been returning the full stack traces to the frontend, however this is not necessary, especially since they may reveal some internal information.