### PR TITLE
chore(sso): improve client secret security

### DIFF
--- a/pkg/apiserver/user/sso/router.go
+++ b/pkg/apiserver/user/sso/router.go
@@ -111,6 +111,8 @@ func (s *Service) getConfig(c *gin.Context) {
 		rest.Error(c, err)
 		return
 	}
+	// Hide client secret for security
+	dc.SSO.CoreConfig.ClientSecret = ""
 	c.JSON(http.StatusOK, dc.SSO.CoreConfig)
 }
 

--- a/pkg/config/dynamic_config_manager.go
+++ b/pkg/config/dynamic_config_manager.go
@@ -164,7 +164,8 @@ func (m *DynamicConfigManager) load() (*DynamicConfig, error) {
 		log.Warn("Dynamic config does not exist in etcd")
 		return nil, nil
 	case 1:
-		log.Info("Load dynamic config from etcd", zap.ByteString("json", resp.Kvs[0].Value))
+		// the log contains the sso client secret, so we should not log it
+		// log.Info("Load dynamic config from etcd", zap.ByteString("json", resp.Kvs[0].Value))
 		var dc DynamicConfig
 		if err = json.Unmarshal(resp.Kvs[0].Value, &dc); err != nil {
 			return nil, err
@@ -185,7 +186,8 @@ func (m *DynamicConfigManager) store(dc *DynamicConfig) error {
 	ctx, cancel := context.WithTimeout(m.lifecycleCtx, Timeout)
 	defer cancel()
 	_, err = m.etcdClient.Put(ctx, DynamicConfigPath, string(bs))
-	log.Info("Save dynamic config to etcd", zap.ByteString("json", bs))
+	// the log contains the sso client secret, so we should not log it
+	// log.Info("Save dynamic config to etcd", zap.ByteString("json", bs))
 
 	return err
 }

--- a/ui/packages/tidb-dashboard-lib/src/apps/UserProfile/components/Form.SSO.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/UserProfile/components/Form.SSO.tsx
@@ -252,44 +252,47 @@ export function SSOForm() {
                   label={t('user_profile.sso.form.client_id')}
                   rules={[{ required: true }]}
                 >
-                  <Input
-                    width={400}
-                    disabled={!isWriteable}
-                    style={DEFAULT_FORM_ITEM_STYLE}
-                  />
+                  <Input disabled={!isWriteable} style={{ width: 320 }} />
                 </Form.Item>
-                <Form.Item
-                  name="client_secret"
-                  label={t('user_profile.sso.form.client_secret')}
-                  rules={[{ required: false }]}
-                >
-                  <Input
-                    width={400}
-                    type="password"
-                    disabled={!isWriteable}
-                    style={DEFAULT_FORM_ITEM_STYLE}
-                  />
-                </Form.Item>
-                {/* <Form.Item
-                  name="scopes"
-                  label={t('user_profile.sso.form.scopes')}
-                  rules={[{ required: false }]}
-                >
-                  <Input
-                    disabled={!isWriteable}
-                    style={DEFAULT_FORM_ITEM_STYLE}
-                    placeholder="openid profile email"
-                  />
-                </Form.Item> */}
+                {
+                  // to compatible with old version
+                  config?.client_secret !== undefined && (
+                    <Form.Item
+                      name="client_secret"
+                      label={t('user_profile.sso.form.client_secret')}
+                      rules={[{ required: false }]}
+                      tooltip={t('user_profile.sso.form.client_secret_tooltip')}
+                    >
+                      <Input
+                        disabled={!isWriteable}
+                        style={{ width: 320 }}
+                        placeholder="********"
+                      />
+                    </Form.Item>
+                  )
+                }
+                {
+                  // we can uncomment this if we really need it
+                  /* <Form.Item
+                    name="scopes"
+                    label={t('user_profile.sso.form.scopes')}
+                    rules={[{ required: false }]}
+                  >
+                    <Input
+                      disabled={!isWriteable}
+                      style={{width: 320}}
+                      placeholder="openid profile email"
+                    />
+                  </Form.Item> */
+                }
                 <Form.Item
                   name="discovery_url"
                   label={t('user_profile.sso.form.discovery_url')}
                   rules={[{ required: true }]}
                 >
                   <Input
-                    width={400}
                     disabled={!isWriteable}
-                    style={DEFAULT_FORM_ITEM_STYLE}
+                    style={{ width: 320 }}
                     placeholder="https://example.com"
                   />
                 </Form.Item>

--- a/ui/packages/tidb-dashboard-lib/src/apps/UserProfile/components/Form.SSO.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/UserProfile/components/Form.SSO.tsx
@@ -253,6 +253,7 @@ export function SSOForm() {
                   rules={[{ required: true }]}
                 >
                   <Input
+                    width={400}
                     disabled={!isWriteable}
                     style={DEFAULT_FORM_ITEM_STYLE}
                   />
@@ -263,11 +264,13 @@ export function SSOForm() {
                   rules={[{ required: false }]}
                 >
                   <Input
+                    width={400}
+                    type="password"
                     disabled={!isWriteable}
                     style={DEFAULT_FORM_ITEM_STYLE}
                   />
                 </Form.Item>
-                <Form.Item
+                {/* <Form.Item
                   name="scopes"
                   label={t('user_profile.sso.form.scopes')}
                   rules={[{ required: false }]}
@@ -277,13 +280,14 @@ export function SSOForm() {
                     style={DEFAULT_FORM_ITEM_STYLE}
                     placeholder="openid profile email"
                   />
-                </Form.Item>
+                </Form.Item> */}
                 <Form.Item
                   name="discovery_url"
                   label={t('user_profile.sso.form.discovery_url')}
                   rules={[{ required: true }]}
                 >
                   <Input
+                    width={400}
                     disabled={!isWriteable}
                     style={DEFAULT_FORM_ITEM_STYLE}
                     placeholder="https://example.com"

--- a/ui/packages/tidb-dashboard-lib/src/apps/UserProfile/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/UserProfile/translations/en.yaml
@@ -7,6 +7,7 @@ user_profile:
     form:
       client_id: OIDC Client ID
       client_secret: OIDC Client Secret
+      client_secret_tooltip: Optional, it is needed when using "Client Secret Post" authentication method, and it is only can be seen when setting.
       scopes: Additional OIDC Scopes (space-separated)
       discovery_url: OIDC Discovery URL
       is_read_only: Sign in as read-only privilege

--- a/ui/packages/tidb-dashboard-lib/src/apps/UserProfile/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/UserProfile/translations/zh.yaml
@@ -7,6 +7,7 @@ user_profile:
     form:
       client_id: OIDC Client ID
       client_secret: OIDC Client Secret
+      client_secret_tooltip: 可选，使用 "Client Secret Post" 认证方法时需要，且仅在设置时可见。
       scopes: 附加 OIDC Scope（空格分隔）
       discovery_url: OIDC Discovery URL
       is_read_only: 以只读权限登录


### PR DESCRIPTION
Related PR: https://github.com/pingcap/tidb-dashboard/pull/1567, it adds support for "Client Secret Post" authentication method. (When you create a `regular web app` in auth0 console, it uses the "Client Secret Post" authentication method).

This PR handle the compatibility with old version, and hide the client secret for security.


### Test

1. Login [Auth0](https://auth0.com/) by google account
2. Create a "Regular Web App" and "Single Web App" applications in the Auth0
![image](https://github.com/pingcap/tidb-dashboard/assets/1284531/42a9e3a1-9298-47df-a9a5-9aba1b824f16)

4. Set the `Allowed Callback URLs` and `Allowed Logout URLs` for the above applications, following the steps in the https://docs.pingcap.com/tidb/stable/dashboard-session-sso#example-2-use-auth0-for-tidb-dashboard-sso-sign-in
![image](https://github.com/pingcap/tidb-dashboard/assets/1284531/4febd574-b8d4-4ee2-b73e-ec992437e080)

6. In tidb-dashboard, go to sso configuration page, fill the `OIDC Client ID`. If the `Client ID` comes from auth0 single web app, we don't need to fill `OIDC Client Secret`. If the `Client ID` comes from auth0 regular web app, we need to fill the `OIDC Client Secret` as well.
7. Logout and Login via SSO.

### Demo

https://github.com/pingcap/tidb-dashboard/assets/1284531/cd6a658e-8c53-466c-98fc-d3cb448e63d1
