### PR TITLE
profiling: Pass the TLS certificate to jeprof

### DIFF
--- a/pkg/apiserver/profiling/fetcher.go
+++ b/pkg/apiserver/profiling/fetcher.go
@@ -15,7 +15,6 @@ import (
 
 	"go.uber.org/fx"
 
-	"github.com/pingcap/log"
 	"github.com/pingcap/tidb-dashboard/pkg/config"
 	"github.com/pingcap/tidb-dashboard/pkg/pd"
 	"github.com/pingcap/tidb-dashboard/pkg/tidb"
@@ -81,14 +80,12 @@ func (f *tikvFetcher) fetch(op *fetchOptions) ([]byte, error) {
 		cmd := exec.Command("perl", "/dev/stdin", "--raw", scheme+"://"+op.ip+":"+strconv.Itoa(op.port)+op.path) //nolint:gosec
 		cmd.Stdin = strings.NewReader(jeprof)
 		if f.client.GetTLSInfo() != nil {
-			str := fmt.Sprintf(
+			cmd.Env = append(os.Environ(), fmt.Sprintf(
 				"URL_FETCHER=curl -s --cert %s --key %s --cacert %s",
 				f.client.GetTLSInfo().CertFile,
 				f.client.GetTLSInfo().KeyFile,
 				f.client.GetTLSInfo().TrustedCAFile,
-			)
-			log.Info(fmt.Sprintf("fetch tikv heap profile %v", str))
-			cmd.Env = append(os.Environ(), str)
+			))
 		}
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {

--- a/pkg/apiserver/profiling/fetcher.go
+++ b/pkg/apiserver/profiling/fetcher.go
@@ -80,6 +80,7 @@ func (f *tikvFetcher) fetch(op *fetchOptions) ([]byte, error) {
 		scheme := f.client.GetHTTPScheme()
 		cmd := exec.Command("perl", "/dev/stdin", "--raw", scheme+"://"+op.ip+":"+strconv.Itoa(op.port)+op.path) //nolint:gosec
 		cmd.Stdin = strings.NewReader(jeprof)
+		log.Info(fmt.Sprintf("fetch tikv heap profile %v", f.client.GetTLSInfo()))
 		if f.client.GetTLSInfo() != nil {
 			cmd.Env = append(os.Environ(),
 				fmt.Sprintf(
@@ -89,7 +90,6 @@ func (f *tikvFetcher) fetch(op *fetchOptions) ([]byte, error) {
 					f.client.GetTLSInfo().TrustedCAFile,
 				),
 			)
-			log.Info(fmt.Sprintf("fetch tikv heap profile with TLS %v", cmd.Env))
 		}
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {

--- a/pkg/apiserver/profiling/fetcher.go
+++ b/pkg/apiserver/profiling/fetcher.go
@@ -82,15 +82,13 @@ func (f *tikvFetcher) fetch(op *fetchOptions) ([]byte, error) {
 		cmd.Stdin = strings.NewReader(jeprof)
 		if f.client.GetTLSInfo() != nil {
 			str := fmt.Sprintf(
-				"URL_FETCHER='curl -s --cert %s --key %s --cacert %s'",
+				"URL_FETCHER=curl -s --cert %s --key %s --cacert %s",
 				f.client.GetTLSInfo().CertFile,
 				f.client.GetTLSInfo().KeyFile,
 				f.client.GetTLSInfo().TrustedCAFile,
 			)
 			log.Info(fmt.Sprintf("fetch tikv heap profile %v", str))
-			cmd.Env = append(os.Environ(),
-				str,
-			)
+			cmd.Env = append(os.Environ(), str)
 		}
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {

--- a/pkg/apiserver/profiling/fetcher.go
+++ b/pkg/apiserver/profiling/fetcher.go
@@ -80,11 +80,11 @@ func (f *tikvFetcher) fetch(op *fetchOptions) ([]byte, error) {
 		scheme := f.client.GetHTTPScheme()
 		cmd := exec.Command("perl", "/dev/stdin", "--raw", scheme+"://"+op.ip+":"+strconv.Itoa(op.port)+op.path) //nolint:gosec
 		cmd.Stdin = strings.NewReader(jeprof)
-		log.Info(fmt.Sprintf("fetch tikv heap profile %v", f.client.GetTLSInfo()))
 		if f.client.GetTLSInfo() != nil {
+			log.Info(fmt.Sprintf("fetch tikv heap profile %v", f.client.GetTLSInfo()))
 			cmd.Env = append(os.Environ(),
 				fmt.Sprintf(
-					"URL_FETCHER=\"curl -s --cert %s --key %s --cacert %s\"",
+					"URL_FETCHER='curl -s --cert %s --key %s --cacert %s'",
 					f.client.GetTLSInfo().CertFile,
 					f.client.GetTLSInfo().KeyFile,
 					f.client.GetTLSInfo().TrustedCAFile,

--- a/pkg/apiserver/profiling/fetcher.go
+++ b/pkg/apiserver/profiling/fetcher.go
@@ -81,14 +81,15 @@ func (f *tikvFetcher) fetch(op *fetchOptions) ([]byte, error) {
 		cmd := exec.Command("perl", "/dev/stdin", "--raw", scheme+"://"+op.ip+":"+strconv.Itoa(op.port)+op.path) //nolint:gosec
 		cmd.Stdin = strings.NewReader(jeprof)
 		if f.client.GetTLSInfo() != nil {
-			log.Info(fmt.Sprintf("fetch tikv heap profile %v", f.client.GetTLSInfo()))
+			str := fmt.Sprintf(
+				"URL_FETCHER='curl -s --cert %s --key %s --cacert %s'",
+				f.client.GetTLSInfo().CertFile,
+				f.client.GetTLSInfo().KeyFile,
+				f.client.GetTLSInfo().TrustedCAFile,
+			)
+			log.Info(fmt.Sprintf("fetch tikv heap profile %v", str))
 			cmd.Env = append(os.Environ(),
-				fmt.Sprintf(
-					"URL_FETCHER='curl -s --cert %s --key %s --cacert %s'",
-					f.client.GetTLSInfo().CertFile,
-					f.client.GetTLSInfo().KeyFile,
-					f.client.GetTLSInfo().TrustedCAFile,
-				),
+				str,
 			)
 		}
 		stdout, err := cmd.StdoutPipe()

--- a/pkg/apiserver/profiling/jeprof.in
+++ b/pkg/apiserver/profiling/jeprof.in
@@ -5324,23 +5324,12 @@ sub cleanup {
   unlink($main::tmpfile_sym);
   unlink(keys %main::tempnames);
 
-  # We leave any collected profiles in $HOME/jeprof in case the user wants
-  # to look at them later.  We print a message informing them of this.
   if ((scalar(@main::profile_files) > 0) &&
       defined($main::collected_profile)) {
     my @profiles = split(" \\\n    ", $main::collected_profile);
     foreach my $profile (@profiles) {
       unlink($profile);
     }
-    # if (scalar(@main::profile_files) == 1) {
-    #   print STDERR "Dynamically gathered profile is in $main::collected_profile\n";
-    # }
-    # print STDERR "If you want to investigate this profile further, you can do:\n";
-    # print STDERR "\n";
-    # print STDERR "  jeprof \\\n";
-    # print STDERR "    $main::prog \\\n";
-    # print STDERR "    $main::collected_profile\n";
-    # print STDERR "\n";
   }
 }
 

--- a/pkg/apiserver/profiling/jeprof.in
+++ b/pkg/apiserver/profiling/jeprof.in
@@ -245,6 +245,7 @@ Miscellaneous:
 Environment Variables:
    JEPROF_TMPDIR        Profiles directory. Defaults to \$HOME/jeprof
    JEPROF_TOOLS         Prefix for object tools pathnames
+   URL_FETCHER          Command to fetch remote profiles
 
 Examples:
 
@@ -521,6 +522,11 @@ sub Init() {
   $main::prog = "";
   @main::pfile_args = ();
 
+  # Override url_fetcher variable if URL_FETCHER environment variable is set
+  if ($ENV{URL_FETCHER}) {
+    @URL_FETCHER = split(' ', $ENV{URL_FETCHER});
+  }
+
   # Remote profiling without a binary (using $SYMBOL_PAGE instead)
   if (@ARGV > 0) {
     if (IsProfileURL($ARGV[0])) {
@@ -688,15 +694,15 @@ sub Main() {
   my $symbol_map = {};
 
   # Read one profile, pick the last item on the list
-  my $data = ReadProfile($main::prog, pop(@main::profile_files));
+  my $data = ReadProfile($main::prog, $main::profile_files[0]);
   my $profile = $data->{profile};
   my $pcs = $data->{pcs};
   my $libs = $data->{libs};   # Info about main program and shared libraries
   $symbol_map = MergeSymbols($symbol_map, $data->{symbols});
 
   # Add additional profiles, if available.
-  if (scalar(@main::profile_files) > 0) {
-    foreach my $pname (@main::profile_files) {
+  if (scalar(@main::profile_files) > 1) {
+    foreach my $pname (@main::profile_files[1..$#main::profile_files]) {
       my $data2 = ReadProfile($main::prog, $pname);
       $profile = AddProfile($profile, $data2->{profile});
       $pcs = AddPcs($pcs, $data2->{pcs});
@@ -3359,21 +3365,18 @@ sub ParseProfileURL {
   my $prefix = $3;
   my $profile = $4 || "/";
 
-  my $host = $hostport;
-  $host =~ s/:.*//;
-
   my $baseurl = "$proto$hostport$prefix";
-  return ($host, $baseurl, $profile);
+  return ($hostport, $baseurl, $profile);
 }
 
 # We fetch symbols from the first profile argument.
 sub SymbolPageURL {
-  my ($host, $baseURL, $path) = ParseProfileURL($main::pfile_args[0]);
+  my ($hostport, $baseURL, $path) = ParseProfileURL($main::pfile_args[0]);
   return "$baseURL$SYMBOL_PAGE";
 }
 
 sub FetchProgramName() {
-  my ($host, $baseURL, $path) = ParseProfileURL($main::pfile_args[0]);
+  my ($hostport, $baseURL, $path) = ParseProfileURL($main::pfile_args[0]);
   my $url = "$baseURL$PROGRAM_NAME_PAGE";
   my $command_line = ShellEscape(@URL_FETCHER, $url);
   open(CMDLINE, "$command_line |") or error($command_line);
@@ -3550,10 +3553,10 @@ sub BaseName {
 
 sub MakeProfileBaseName {
   my ($binary_name, $profile_name) = @_;
-  my ($host, $baseURL, $path) = ParseProfileURL($profile_name);
+  my ($hostport, $baseURL, $path) = ParseProfileURL($profile_name);
   my $binary_shortname = BaseName($binary_name);
   return sprintf("%s.%s.%s",
-                 $binary_shortname, $main::op_time, $host);
+                 $binary_shortname, $main::op_time, $hostport);
 }
 
 sub FetchDynamicProfile {
@@ -3565,7 +3568,7 @@ sub FetchDynamicProfile {
   if (!IsProfileURL($profile_name)) {
     return $profile_name;
   } else {
-    my ($host, $baseURL, $path) = ParseProfileURL($profile_name);
+    my ($hostport, $baseURL, $path) = ParseProfileURL($profile_name);
     if ($path eq "" || $path eq "/") {
       # Missing type specifier defaults to cpu-profile
       $path = $PROFILE_PAGE;
@@ -5325,15 +5328,19 @@ sub cleanup {
   # to look at them later.  We print a message informing them of this.
   if ((scalar(@main::profile_files) > 0) &&
       defined($main::collected_profile)) {
-    if (scalar(@main::profile_files) == 1) {
-      print STDERR "Dynamically gathered profile is in $main::collected_profile\n";
+    my @profiles = split(" \\\n    ", $main::collected_profile);
+    foreach my $profile (@profiles) {
+      unlink($profile);
     }
-    print STDERR "If you want to investigate this profile further, you can do:\n";
-    print STDERR "\n";
-    print STDERR "  jeprof \\\n";
-    print STDERR "    $main::prog \\\n";
-    print STDERR "    $main::collected_profile\n";
-    print STDERR "\n";
+    # if (scalar(@main::profile_files) == 1) {
+    #   print STDERR "Dynamically gathered profile is in $main::collected_profile\n";
+    # }
+    # print STDERR "If you want to investigate this profile further, you can do:\n";
+    # print STDERR "\n";
+    # print STDERR "  jeprof \\\n";
+    # print STDERR "    $main::prog \\\n";
+    # print STDERR "    $main::collected_profile\n";
+    # print STDERR "\n";
   }
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/tidb-dashboard/pkg/utils/version"
+	"go.etcd.io/etcd/pkg/transport"
 )
 
 const (
@@ -24,8 +25,9 @@ type Config struct {
 	PDEndPoint       string
 	PublicPathPrefix string
 
-	ClusterTLSConfig *tls.Config // TLS config for mTLS authentication between TiDB components.
-	TiDBTLSConfig    *tls.Config // TLS config for mTLS authentication between TiDB and MySQL client.
+	ClusterTLSConfig *tls.Config        // TLS config for mTLS authentication between TiDB components.
+	ClusterTLSInfo   *transport.TLSInfo // TLS info for mTLS authentication between TiDB components.
+	TiDBTLSConfig    *tls.Config        // TLS config for mTLS authentication between TiDB and MySQL client.
 
 	EnableTelemetry    bool
 	EnableExperimental bool

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,7 @@ func Default() *Config {
 		PDEndPoint:         "http://127.0.0.1:2379",
 		PublicPathPrefix:   defaultPublicPathPrefix,
 		ClusterTLSConfig:   nil,
+		ClusterTLSInfo: 	nil,	
 		TiDBTLSConfig:      nil,
 		EnableTelemetry:    false,
 		EnableExperimental: false,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,8 +7,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/pingcap/tidb-dashboard/pkg/utils/version"
 	"go.etcd.io/etcd/pkg/transport"
+
+	"github.com/pingcap/tidb-dashboard/pkg/utils/version"
 )
 
 const (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,7 +43,7 @@ func Default() *Config {
 		PDEndPoint:         "http://127.0.0.1:2379",
 		PublicPathPrefix:   defaultPublicPathPrefix,
 		ClusterTLSConfig:   nil,
-		ClusterTLSInfo: 	nil,	
+		ClusterTLSInfo:     nil,
 		TiDBTLSConfig:      nil,
 		EnableTelemetry:    false,
 		EnableExperimental: false,

--- a/pkg/tikv/client.go
+++ b/pkg/tikv/client.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"go.etcd.io/etcd/pkg/transport"
 	"go.uber.org/fx"
 
 	"github.com/pingcap/tidb-dashboard/pkg/config"
@@ -29,6 +30,7 @@ type Client struct {
 	httpScheme   string
 	lifecycleCtx context.Context
 	timeout      time.Duration
+	tlsInfo      *transport.TLSInfo
 }
 
 func NewTiKVClient(lc fx.Lifecycle, httpClient *httpc.Client, config *config.Config) *Client {
@@ -37,6 +39,7 @@ func NewTiKVClient(lc fx.Lifecycle, httpClient *httpc.Client, config *config.Con
 		httpScheme:   config.GetClusterHTTPScheme(),
 		lifecycleCtx: nil,
 		timeout:      defaultTiKVStatusAPITimeout,
+		tlsInfo:      config.ClusterTLSInfo,
 	}
 
 	lc.Append(fx.Hook{
@@ -57,6 +60,14 @@ func (c Client) WithTimeout(timeout time.Duration) *Client {
 func (c Client) AddRequestHeader(key, value string) *Client {
 	c.httpClient = c.httpClient.CloneAndAddRequestHeader(key, value)
 	return &c
+}
+
+func (c *Client) GetHTTPScheme() string {
+	return c.httpScheme
+}
+
+func (c *Client) GetTLSInfo() *transport.TLSInfo {
+	return c.tlsInfo
 }
 
 func (c *Client) Get(host string, statusPort int, relativeURI string) (*httpc.Response, error) {


### PR DESCRIPTION
Fix https://github.com/pingcap/tidb-dashboard/issues/1613

Fix it by passing the TLS certificate to jeprof. 

By the way, fix some potential issues in jeprof:
- Join the port to jeprof temporarily file name, otherwise multiple instances deployed in the same host may write to same temp file
- Clean up collected profile files when finished instead of keeping them

Manual Test:
![8e6e2b17-272f-44e0-a64f-9a52f3c3de28](https://github.com/pingcap/tidb-dashboard/assets/13497871/4a9a5279-c511-4913-8bca-0101eb81fb77)
