### PR TITLE
fix: remove duplicated `v` in version showing in the banner

### DIFF
--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/dashboardApp/layout/main/Sider/Banner.tsx
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/dashboardApp/layout/main/Sider/Banner.tsx
@@ -35,7 +35,11 @@ function parseVersion(i: InfoInfoResponse, t: TFunction) {
     }
     if (i.version.internal_version) {
       // e.g. v2020.07.01.1
-      return `v${i.version.internal_version}`
+      if (i.version.internal_version.startsWith('v')) {
+        return i.version.internal_version
+      } else {
+        return `v${i.version.internal_version}`
+      }
     }
     return null
   }

--- a/ui/packages/tidb-dashboard-for-op/src/dashboardApp/layout/main/Sider/Banner.tsx
+++ b/ui/packages/tidb-dashboard-for-op/src/dashboardApp/layout/main/Sider/Banner.tsx
@@ -35,7 +35,11 @@ function parseVersion(i: InfoInfoResponse, t: TFunction) {
     }
     if (i.version.internal_version) {
       // e.g. v2020.07.01.1
-      return `v${i.version.internal_version}`
+      if (i.version.internal_version.startsWith('v')) {
+        return i.version.internal_version
+      } else {
+        return `v${i.version.internal_version}`
+      }
     }
     return null
   }


### PR DESCRIPTION
This PR fixes the following error which has duplicated `v` in version showing in the banner:

![image](https://github.com/pingcap/tidb-dashboard/assets/1284531/6559d05f-0907-44bf-abd5-16fcdd9b7978)
