### PR TITLE
statement,slowquery: add request unit part in the detail page

### DIFF
--- a/pkg/apiserver/statement/models.go
+++ b/pkg/apiserver/statement/models.go
@@ -108,6 +108,8 @@ type Model struct {
 	AggAvgRU         float64 `json:"avg_ru" agg:"CAST(AVG(avg_request_unit_write + avg_request_unit_read) AS DECIMAL(64, 2))" related:"avg_request_unit_write,avg_request_unit_read"`
 	AggMaxRU         float64 `json:"max_ru" agg:"MAX(max_request_unit_write + max_request_unit_read)" related:"max_request_unit_write,max_request_unit_read"`
 	AggSumRU         float64 `json:"sum_ru" agg:"CAST(SUM(exec_count * (avg_request_unit_write + avg_request_unit_read)) AS DECIMAL(64, 2))" related:"avg_request_unit_write,avg_request_unit_read"`
+	AvgQueuedTime    float64 `json:"avg_time_queued_by_rc" agg:"CAST(AVG(AVG_QUEUED_RC_TIME) AS DECIMAL(64, 2))" related:"AVG_QUEUED_RC_TIME"`
+	MaxQueuedTime    float64 `json:"max_time_queued_by_rc" agg:"Max(MAX_QUEUED_RC_TIME)" related:"MAX_QUEUED_RC_TIME"`
 }
 
 // tableNames example: "d1.a1,d2.a2,d1.a1,d3.a3"

--- a/ui/packages/tidb-dashboard-client/src/client/api/models/statement-model.ts
+++ b/ui/packages/tidb-dashboard-client/src/client/api/models/statement-model.ts
@@ -169,6 +169,12 @@ export interface StatementModel {
      * @type {number}
      * @memberof StatementModel
      */
+    'avg_time_queued_by_rc'?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof StatementModel
+     */
     'avg_total_keys'?: number;
     /**
      * 
@@ -386,6 +392,12 @@ export interface StatementModel {
      * @memberof StatementModel
      */
     'max_ru'?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof StatementModel
+     */
+    'max_time_queued_by_rc'?: number;
     /**
      * 
      * @type {number}

--- a/ui/packages/tidb-dashboard-client/swagger/spec.json
+++ b/ui/packages/tidb-dashboard-client/swagger/spec.json
@@ -5384,6 +5384,9 @@
                 "avg_ru": {
                     "type": "number"
                 },
+                "avg_time_queued_by_rc": {
+                    "type": "number"
+                },
                 "avg_total_keys": {
                     "type": "integer"
                 },
@@ -5499,6 +5502,9 @@
                     "type": "integer"
                 },
                 "max_ru": {
+                    "type": "number"
+                },
+                "max_time_queued_by_rc": {
                     "type": "number"
                 },
                 "max_total_keys": {

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/Detail/DetailTabBasic.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/Detail/DetailTabBasic.tsx
@@ -29,5 +29,7 @@ export const tabBasicItems = (data: SlowqueryModel) => [
   { key: 'instance', value: data.instance },
   { key: 'connection_id', value: data.connection_id },
   { key: 'user', value: data.user },
-  { key: 'host', value: data.host }
+  { key: 'host', value: data.host },
+  { key: 'ru', value: data.ru },
+  { key: 'resource_group', value: data.resource_group }
 ]

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/Detail/DetailTabTime.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/Detail/DetailTabTime.tsx
@@ -114,6 +114,11 @@ export const tabTimeItems = (data: SlowqueryModel, t: TFunction) => {
       key: 'wait_prewrite_binlog_time',
       value: data.wait_prewrite_binlog_time! * 10e8,
       indentLevel: 1
+    },
+    {
+      key: 'time_queued_by_rc',
+      value: data.time_queued_by_rc! * 10e8,
+      indentLevel: 1
     }
   ]
 }

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanDetailTabBasic.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanDetailTabBasic.tsx
@@ -65,5 +65,17 @@ export const tabBasicItems = (data: StatementModel) => [
   {
     key: 'max_disk',
     value: getValueFormat('bytes')(data.max_disk || 0, 1)
+  },
+  {
+    key: 'avg_ru',
+    value: getValueFormat('short')(data.avg_ru || 0, 1)
+  },
+  {
+    key: 'max_ru',
+    value: getValueFormat('short')(data.max_ru || 0, 1)
+  },
+  {
+    key: 'resource_group',
+    value: data.resource_group
   }
 ]

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanDetailTabTime.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/Detail/PlanDetailTabTime.tsx
@@ -56,6 +56,11 @@ export const tabTimeItems = (data: StatementModel, t: TFunction) => [
     max: data.max_commit_backoff_time
   },
   {
+    key: 'rc_wait_time',
+    avg: data.avg_time_queued_by_rc,
+    max: data.max_time_queued_by_rc
+  },
+  {
     key: 'query_time2',
     keyDisplay: (
       <Typography.Text strong>

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/en.yaml
@@ -188,6 +188,13 @@ statement:
     resource_group: Resource Group
     resource_group_tooltip: The resource group that the query belongs to
     avg_ru: Mean RU
-    avg_ru_tooltip: The average number of request units (RU) consumed by the query
+    avg_ru_tooltip: The average number of request units (RU) consumed by the statement
+    max_ru: Max RU
+    max_ru_tooltip: The maximum number of request units (RU) consumed by the statement
     sum_ru: Total RU
-    sum_ru_tooltip: The total number of request units (RU) consumed by the query
+    sum_ru_tooltip: The total number of request units (RU) consumed by the statement
+    avg_time_queued_by_rc: Mean RC Wait Time in Queue
+    avg_time_queued_by_rc_tooltip: The average time that the query waits in the resource control's queue
+    max_time_queued_by_rc: Max RC Wait Time in Queue
+    max_time_queued_by_rc_tooltip: The maximum time that the query waits in the resource control's queue
+    rc_wait_time: Wait Time in Resource Control

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
@@ -195,6 +195,13 @@ statement:
     resource_group: 资源组
     resource_group_tooltip: SQL 语句所属的资源组
     avg_ru: 平均 RU
-    avg_ru_tooltip: SQL 语句的平均 RU
+    avg_ru_tooltip: Statement 语句的平均 RU
+    max_ru: 最大 RU
+    max_ru_tooltip: 该 Statement 执行中使用过的最大 RU
     sum_ru: 累积 RU
-    sum_ru_tooltip: SQL 语句的 RU 累积值
+    sum_ru_tooltip: 该 Statement 的 RU 累积值
+    avg_time_queued_by_rc: RC 平均等待耗时
+    avg_time_queued_by_rc_tooltip: SQL 语句在资源组控制队列中平均等待的时间 (Resource Control)
+    max_time_queued_by_rc: RC 最大等待耗时
+    max_time_queued_by_rc_tooltip: SQL 语句在资源组控制队列中最大等待的时间 (Resource Control)
+    rc_wait_time: RC 资源控制等待耗时

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/utils/tableColumns.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/utils/tableColumns.tsx
@@ -97,7 +97,11 @@ export const derivedFields = {
     'avg_rocksdb_block_read_byte',
     'max_rocksdb_block_read_byte'
   ),
-  avg_ru: genDerivedBarSources('avg_ru', 'max_ru')
+  avg_ru: genDerivedBarSources('avg_ru', 'max_ru'),
+  avg_time_queued_by_rc: genDerivedBarSources(
+    'avg_time_queued_by_rc',
+    'max_time_queued_by_rc'
+  )
 }
 
 //////////////////////////////////////////
@@ -282,7 +286,8 @@ export function statementColumns(
       minWidth: 100,
       maxWidth: 300,
       columnActionsMode: ColumnActionsMode.clickable
-    })
+    }),
+    avgMaxColumn(tcf, 'avg_time_queued_by_rc', 'ns', rows)
   ])
 }
 

--- a/ui/packages/tidb-dashboard-lib/src/client/models.ts
+++ b/ui/packages/tidb-dashboard-lib/src/client/models.ts
@@ -2963,6 +2963,12 @@ export interface StatementModel {
      * @type {number}
      * @memberof StatementModel
      */
+    'avg_time_queued_by_rc'?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof StatementModel
+     */
     'avg_total_keys'?: number;
     /**
      * 
@@ -3180,6 +3186,12 @@ export interface StatementModel {
      * @memberof StatementModel
      */
     'max_ru'?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof StatementModel
+     */
+    'max_time_queued_by_rc'?: number;
     /**
      * 
      * @type {number}


### PR DESCRIPTION
## Statement:
<img src="https://github.com/pingcap/tidb-dashboard/assets/6428910/6c44f802-34ab-4bfb-9099-b29ec31a25a1" alt="Image" width="600">
<img src="https://github.com/pingcap/tidb-dashboard/assets/6428910/f496d0d8-b1bc-4acf-af77-ed80d11438a1" alt="Image" width="600">

## Slow Query
<img src="https://github.com/pingcap/tidb-dashboard/assets/6428910/63263f02-51f8-45fd-8481-c6a81b8c0831" alt="Image" width="600">
<img src="https://github.com/pingcap/tidb-dashboard/assets/6428910/5fdb04d9-ace5-42ca-80e2-cc2db0659686" alt="Image" width="600">


