### PR TITLE
feat(slow-query): support slow query search by resource group

### DIFF
--- a/pkg/apiserver/slowquery/queries.go
+++ b/pkg/apiserver/slowquery/queries.go
@@ -15,13 +15,14 @@ const (
 )
 
 type GetListRequest struct {
-	BeginTime int      `json:"begin_time" form:"begin_time"`
-	EndTime   int      `json:"end_time" form:"end_time"`
-	DB        []string `json:"db" form:"db"`
-	Limit     int      `json:"limit" form:"limit"`
-	Text      string   `json:"text" form:"text"`
-	OrderBy   string   `json:"orderBy" form:"orderBy"`
-	IsDesc    bool     `json:"desc" form:"desc"`
+	BeginTime     int      `json:"begin_time" form:"begin_time"`
+	EndTime       int      `json:"end_time" form:"end_time"`
+	DB            []string `json:"db" form:"db"`
+	ResourceGroup []string `json:"resource_group" form:"resource_group"`
+	Limit         int      `json:"limit" form:"limit"`
+	Text          string   `json:"text" form:"text"`
+	OrderBy       string   `json:"orderBy" form:"orderBy"`
+	IsDesc        bool     `json:"desc" form:"desc"`
 
 	// for showing slow queries in the statement detail page
 	Plans  []string `json:"plans" form:"plans"`
@@ -77,6 +78,10 @@ func QuerySlowLogList(req *GetListRequest, sysSchema *utils.SysSchema, db *gorm.
 
 	if len(req.DB) > 0 {
 		tx = tx.Where("DB IN (?)", req.DB)
+	}
+
+	if len(req.ResourceGroup) > 0 {
+		tx = tx.Where("RESOURCE_GROUP IN (?)", req.ResourceGroup)
 	}
 
 	// more robust

--- a/ui/packages/tidb-dashboard-client/src/client/api/api/default-api.ts
+++ b/ui/packages/tidb-dashboard-client/src/client/api/api/default-api.ts
@@ -2641,6 +2641,39 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
+         * 
+         * @summary List all resource groups
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        resourceManagerInformationGroupNamesGet: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/resource_manager/information/group_names`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication JwtAuth required
+            await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Get available field names by slowquery table columns
          * @summary Get available field names
          * @param {*} [options] Override http request option.
@@ -2809,11 +2842,12 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {number} [limit] 
          * @param {string} [orderBy] 
          * @param {Array<string>} [plans] for showing slow queries in the statement detail page
+         * @param {Array<string>} [resourceGroup] 
          * @param {string} [text] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        slowQueryListGet: async (beginTime?: number, db?: Array<string>, desc?: boolean, digest?: string, endTime?: number, fields?: string, limit?: number, orderBy?: string, plans?: Array<string>, text?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        slowQueryListGet: async (beginTime?: number, db?: Array<string>, desc?: boolean, digest?: string, endTime?: number, fields?: string, limit?: number, orderBy?: string, plans?: Array<string>, resourceGroup?: Array<string>, text?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/slow_query/list`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2863,6 +2897,10 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
 
             if (plans) {
                 localVarQueryParameter['plans'] = plans;
+            }
+
+            if (resourceGroup) {
+                localVarQueryParameter['resource_group'] = resourceGroup;
             }
 
             if (text !== undefined) {
@@ -4762,6 +4800,16 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
+         * 
+         * @summary List all resource groups
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async resourceManagerInformationGroupNamesGet(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<string>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.resourceManagerInformationGroupNamesGet(options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
          * Get available field names by slowquery table columns
          * @summary Get available field names
          * @param {*} [options] Override http request option.
@@ -4818,12 +4866,13 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {number} [limit] 
          * @param {string} [orderBy] 
          * @param {Array<string>} [plans] for showing slow queries in the statement detail page
+         * @param {Array<string>} [resourceGroup] 
          * @param {string} [text] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async slowQueryListGet(beginTime?: number, db?: Array<string>, desc?: boolean, digest?: string, endTime?: number, fields?: string, limit?: number, orderBy?: string, plans?: Array<string>, text?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<SlowqueryModel>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.slowQueryListGet(beginTime, db, desc, digest, endTime, fields, limit, orderBy, plans, text, options);
+        async slowQueryListGet(beginTime?: number, db?: Array<string>, desc?: boolean, digest?: string, endTime?: number, fields?: string, limit?: number, orderBy?: string, plans?: Array<string>, resourceGroup?: Array<string>, text?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<SlowqueryModel>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.slowQueryListGet(beginTime, db, desc, digest, endTime, fields, limit, orderBy, plans, resourceGroup, text, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -5816,6 +5865,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.resourceManagerInformationGet(options).then((request) => request(axios, basePath));
         },
         /**
+         * 
+         * @summary List all resource groups
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        resourceManagerInformationGroupNamesGet(options?: any): AxiosPromise<Array<string>> {
+            return localVarFp.resourceManagerInformationGroupNamesGet(options).then((request) => request(axios, basePath));
+        },
+        /**
          * Get available field names by slowquery table columns
          * @summary Get available field names
          * @param {*} [options] Override http request option.
@@ -5868,12 +5926,13 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {number} [limit] 
          * @param {string} [orderBy] 
          * @param {Array<string>} [plans] for showing slow queries in the statement detail page
+         * @param {Array<string>} [resourceGroup] 
          * @param {string} [text] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        slowQueryListGet(beginTime?: number, db?: Array<string>, desc?: boolean, digest?: string, endTime?: number, fields?: string, limit?: number, orderBy?: string, plans?: Array<string>, text?: string, options?: any): AxiosPromise<Array<SlowqueryModel>> {
-            return localVarFp.slowQueryListGet(beginTime, db, desc, digest, endTime, fields, limit, orderBy, plans, text, options).then((request) => request(axios, basePath));
+        slowQueryListGet(beginTime?: number, db?: Array<string>, desc?: boolean, digest?: string, endTime?: number, fields?: string, limit?: number, orderBy?: string, plans?: Array<string>, resourceGroup?: Array<string>, text?: string, options?: any): AxiosPromise<Array<SlowqueryModel>> {
+            return localVarFp.slowQueryListGet(beginTime, db, desc, digest, endTime, fields, limit, orderBy, plans, resourceGroup, text, options).then((request) => request(axios, basePath));
         },
         /**
          * Start a profiling task group
@@ -6948,6 +7007,13 @@ export interface DefaultApiSlowQueryListGetRequest {
      * @memberof DefaultApiSlowQueryListGet
      */
     readonly plans?: Array<string>
+
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof DefaultApiSlowQueryListGet
+     */
+    readonly resourceGroup?: Array<string>
 
     /**
      * 
@@ -8190,6 +8256,17 @@ export class DefaultApi extends BaseAPI {
     }
 
     /**
+     * 
+     * @summary List all resource groups
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public resourceManagerInformationGroupNamesGet(options?: AxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).resourceManagerInformationGroupNamesGet(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
      * Get available field names by slowquery table columns
      * @summary Get available field names
      * @param {*} [options] Override http request option.
@@ -8245,7 +8322,7 @@ export class DefaultApi extends BaseAPI {
      * @memberof DefaultApi
      */
     public slowQueryListGet(requestParameters: DefaultApiSlowQueryListGetRequest = {}, options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).slowQueryListGet(requestParameters.beginTime, requestParameters.db, requestParameters.desc, requestParameters.digest, requestParameters.endTime, requestParameters.fields, requestParameters.limit, requestParameters.orderBy, requestParameters.plans, requestParameters.text, options).then((request) => request(this.axios, this.basePath));
+        return DefaultApiFp(this.configuration).slowQueryListGet(requestParameters.beginTime, requestParameters.db, requestParameters.desc, requestParameters.digest, requestParameters.endTime, requestParameters.fields, requestParameters.limit, requestParameters.orderBy, requestParameters.plans, requestParameters.resourceGroup, requestParameters.text, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/ui/packages/tidb-dashboard-client/src/client/api/models/slowquery-get-list-request.ts
+++ b/ui/packages/tidb-dashboard-client/src/client/api/models/slowquery-get-list-request.ts
@@ -76,6 +76,12 @@ export interface SlowqueryGetListRequest {
     'plans'?: Array<string>;
     /**
      * 
+     * @type {Array<string>}
+     * @memberof SlowqueryGetListRequest
+     */
+    'resource_group'?: Array<string>;
+    /**
+     * 
      * @type {string}
      * @memberof SlowqueryGetListRequest
      */

--- a/ui/packages/tidb-dashboard-client/swagger/spec.json
+++ b/ui/packages/tidb-dashboard-client/swagger/spec.json
@@ -2287,6 +2287,33 @@
                 }
             }
         },
+        "/resource_manager/information/group_names": {
+            "get": {
+                "security": [
+                    {
+                        "JwtAuth": []
+                    }
+                ],
+                "summary": "List all resource groups",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/slow_query/available_fields": {
             "get": {
                 "security": [
@@ -2500,6 +2527,15 @@
                         "collectionFormat": "multi",
                         "description": "for showing slow queries in the statement detail page",
                         "name": "plans",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "name": "resource_group",
                         "in": "query"
                     },
                     {
@@ -4955,6 +4991,12 @@
                 },
                 "plans": {
                     "description": "for showing slow queries in the statement detail page",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "resource_group": {
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/SlowQuery/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/SlowQuery/context.ts
@@ -15,6 +15,10 @@ class DataSource implements ISlowQueryDataSource {
     return client.getInstance().infoListDatabases(options)
   }
 
+  infoListResourceGroupNames(options?: ReqConfig) {
+    return client.getInstance().resourceManagerInformationGroupNamesGet(options)
+  }
+
   slowQueryAvailableFieldsGet(options?: ReqConfig) {
     return client.getInstance().slowQueryAvailableFieldsGet(options)
   }
@@ -29,6 +33,7 @@ class DataSource implements ISlowQueryDataSource {
     limit?: number,
     orderBy?: string,
     plans?: Array<string>,
+    resourceGroup?: Array<string>,
     text?: string,
     options?: ReqConfig
   ) {
@@ -43,6 +48,7 @@ class DataSource implements ISlowQueryDataSource {
         limit,
         orderBy,
         plans,
+        resourceGroup,
         text
       },
       options
@@ -132,6 +138,7 @@ export const ctx: (cfg: Partial<ISlowQueryConfig>) => ISlowQueryContext = (
       enableExport: true,
       showDBFilter: true,
       showDigestFilter: false,
+      showResourceGroupFilter: true,
       ...cfg
     }
   }

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Statement/context.ts
@@ -15,6 +15,10 @@ class DataSource implements IStatementDataSource {
     return client.getInstance().infoListDatabases(options)
   }
 
+  infoListResourceGroupNames(options?: ReqConfig) {
+    return client.getInstance().resourceManagerInformationGroupNamesGet(options)
+  }
+
   statementsAvailableFieldsGet(options?: ReqConfig) {
     return client.getInstance().statementsAvailableFieldsGet(options)
   }
@@ -123,6 +127,7 @@ class DataSource implements IStatementDataSource {
     limit?: number,
     orderBy?: string,
     plans?: Array<string>,
+    resourceGroup?: Array<string>,
     text?: string,
     options?: ReqConfig
   ) {
@@ -137,6 +142,7 @@ class DataSource implements IStatementDataSource {
         limit,
         orderBy,
         plans,
+        resourceGroup,
         text
       },
       options

--- a/ui/packages/tidb-dashboard-for-clinic-op/src/apps/SlowQuery/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-op/src/apps/SlowQuery/context.ts
@@ -30,6 +30,17 @@ class DataSource implements ISlowQueryDataSource {
     } as any)
   }
 
+  infoListResourceGroupNames(options?: ReqConfig) {
+    // return Promise.reject(new Error('no need to implemented'))
+    return Promise.resolve({
+      data: [],
+      status: 200,
+      statusText: 'ok',
+      headers: {},
+      config: {}
+    } as any)
+  }
+
   slowQueryAvailableFieldsGet(options?: ReqConfig) {
     // return Promise.reject(new Error('no need to implemented'))
     return Promise.resolve({
@@ -51,6 +62,7 @@ class DataSource implements ISlowQueryDataSource {
     limit?: number,
     orderBy?: string,
     plans?: Array<string>,
+    resourceGroup?: Array<string>,
     text?: string,
     options?: ReqConfig
   ) {
@@ -119,6 +131,7 @@ export const ctx: (extra: DsExtra) => ISlowQueryContext = (extra) => ({
     apiPathBase: client.getBasePath(),
     enableExport: false,
     showDBFilter: false,
-    showDigestFilter: false
+    showDigestFilter: false,
+    showResourceGroupFilter: true
   }
 })

--- a/ui/packages/tidb-dashboard-for-op/src/apps/SlowQuery/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/SlowQuery/context.ts
@@ -11,6 +11,10 @@ class DataSource implements ISlowQueryDataSource {
     return client.getInstance().infoListDatabases(options)
   }
 
+  infoListResourceGroupNames(options?: ReqConfig) {
+    return client.getInstance().resourceManagerInformationGroupNamesGet(options)
+  }
+
   slowQueryAvailableFieldsGet(options?: ReqConfig) {
     return client.getInstance().slowQueryAvailableFieldsGet(options)
   }
@@ -25,6 +29,7 @@ class DataSource implements ISlowQueryDataSource {
     limit?: number,
     orderBy?: string,
     plans?: Array<string>,
+    resourceGroup?: Array<string>,
     text?: string,
     options?: ReqConfig
   ) {
@@ -39,6 +44,7 @@ class DataSource implements ISlowQueryDataSource {
         limit,
         orderBy,
         plans,
+        resourceGroup,
         text
       },
       options
@@ -74,7 +80,8 @@ export const ctx: ISlowQueryContext = {
     apiPathBase: client.getBasePath(),
     enableExport: true,
     showDBFilter: true,
-    showDigestFilter: false
+    showDigestFilter: false,
+    showResourceGroupFilter: true
     // instantQuery: false,
     // timeRangeSelector: {
     //   recentSeconds: [3 * 24 * 60 * 60],

--- a/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
@@ -15,6 +15,10 @@ class DataSource implements IStatementDataSource {
     return client.getInstance().infoListDatabases(options)
   }
 
+  infoListResourceGroupNames(options?: ReqConfig) {
+    return client.getInstance().resourceManagerInformationGroupNamesGet(options)
+  }
+
   statementsAvailableFieldsGet(options?: ReqConfig) {
     return client.getInstance().statementsAvailableFieldsGet(options)
   }
@@ -163,6 +167,7 @@ class DataSource implements IStatementDataSource {
     limit?: number,
     orderBy?: string,
     plans?: Array<string>,
+    resourceGroup?: Array<string>,
     text?: string,
     options?: ReqConfig
   ) {
@@ -177,6 +182,7 @@ class DataSource implements IStatementDataSource {
         limit,
         orderBy,
         plans,
+        resourceGroup,
         text
       },
       options

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/context/index.ts
@@ -10,6 +10,8 @@ import { PromDataSuccessResponse } from '@lib/utils'
 export interface ISlowQueryDataSource {
   infoListDatabases(options?: ReqConfig): AxiosPromise<Array<string>>
 
+  infoListResourceGroupNames(options?: ReqConfig): AxiosPromise<Array<string>>
+
   slowQueryAvailableFieldsGet(options?: ReqConfig): AxiosPromise<Array<string>>
 
   slowQueryListGet(
@@ -22,6 +24,7 @@ export interface ISlowQueryDataSource {
     limit?: number,
     orderBy?: string,
     plans?: Array<string>,
+    resourceGroup?: Array<string>,
     text?: string,
     options?: ReqConfig
   ): AxiosPromise<Array<SlowqueryModel>>
@@ -61,6 +64,7 @@ export interface ISlowQueryEvent {
 export interface ISlowQueryConfig extends IContextConfig {
   enableExport: boolean
   showDBFilter: boolean
+  showResourceGroupFilter: boolean
   showDigestFilter: boolean
   showHelp?: boolean
 

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
@@ -127,6 +127,9 @@ function List() {
   const [filterText, setFilterText] = useState<string>(
     controller.queryOptions.searchText
   )
+  const [filterGroup, setFilterGroup] = useState<string[]>(
+    controller.queryOptions.groups
+  )
 
   const sendQueryNow = useMemoizedFn(() => {
     cacheMgr?.clear()
@@ -137,7 +140,8 @@ function List() {
       searchText: filterText,
       visibleColumnKeys,
       digest: filterDigest,
-      plans: []
+      plans: [],
+      groups: filterGroup
     })
   })
 
@@ -155,7 +159,14 @@ function List() {
       return
     }
     sendQueryDebounced()
-  }, [timeRange, filterSchema, filterLimit, filterText, visibleColumnKeys])
+  }, [
+    timeRange,
+    filterSchema,
+    filterLimit,
+    filterText,
+    filterGroup,
+    visibleColumnKeys
+  ])
 
   const downloadCSV = useMemoizedFn(async () => {
     // use last effective query options
@@ -231,6 +242,23 @@ function List() {
                 data-e2e="execution_database_name"
               />
             )}
+            {ctx!.cfg.showResourceGroupFilter &&
+              controller.allGroups.length > 1 && (
+                <MultiSelect.Plain
+                  placeholder={t(
+                    'slow_query.toolbar.resource_groups.placeholder'
+                  )}
+                  selectedValueTransKey="slow_query.toolbar.resource_groups.selected"
+                  columnTitle={t(
+                    'slow_query.toolbar.resource_groups.columnTitle'
+                  )}
+                  value={filterGroup}
+                  style={{ width: 150 }}
+                  onChange={setFilterGroup}
+                  items={controller.allGroups}
+                  data-e2e="resource_group_name_select"
+                />
+              )}
             <Select
               style={{ width: 150 }}
               value={filterLimit}

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/en.yaml
@@ -156,6 +156,10 @@ slow_query:
       placeholder: All Databases
       selected: '{{ n }} Databases'
       columnTitle: Execution Database Name
+    resource_groups:
+      placeholder: All Resource Groups
+      selected: '{{ n }} Resource Groups'
+      columnTitle: Resource Group Name
     select_columns:
       show_full_sql: Show Full Query Text
     refresh: Refresh

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/zh.yaml
@@ -158,6 +158,10 @@ slow_query:
       placeholder: 所有数据库
       selected: '{{ n }} 数据库'
       columnTitle: 执行数据库名
+    resource_groups:
+      placeholder: 所有资源组
+      selected: '{{ n }} 资源组'
+      columnTitle: 资源组名
     select_columns:
       show_full_sql: 显示完整 SQL 文本
     refresh: 刷新

--- a/ui/packages/tidb-dashboard-lib/src/client/models.ts
+++ b/ui/packages/tidb-dashboard-lib/src/client/models.ts
@@ -2173,6 +2173,12 @@ export interface SlowqueryGetListRequest {
     'plans'?: Array<string>;
     /**
      * 
+     * @type {Array<string>}
+     * @memberof SlowqueryGetListRequest
+     */
+    'resource_group'?: Array<string>;
+    /**
+     * 
      * @type {string}
      * @memberof SlowqueryGetListRequest
      */


### PR DESCRIPTION
support slow query search by resource group
- If there are above 2 resource groups in the cluster, will show the `MultiSelect`
- Add relative API

Example:
![image](https://github.com/pingcap/tidb-dashboard/assets/6428910/667183f5-73f8-4147-8a85-0cf3e538de1c)


