### PR TITLE
feat(statements): support statement search by resource group

### DIFF
--- a/pkg/apiserver/statement/queries.go
+++ b/pkg/apiserver/statement/queries.go
@@ -38,7 +38,7 @@ func queryStmtTypes(db *gorm.DB) (result []string, err error) {
 func (s *Service) queryStatements(
 	db *gorm.DB,
 	beginTime, endTime int,
-	schemas, stmtTypes []string,
+	schemas, resourceGroups, stmtTypes []string,
 	text string,
 	reqFields []string,
 ) (result []Model, err error) {
@@ -67,6 +67,10 @@ func (s *Service) queryStatements(
 		}
 		regexAll := strings.Join(regex, "|")
 		query = query.Where("table_names REGEXP ?", regexAll)
+	}
+
+	if len(resourceGroups) > 0 {
+		query = query.Where("resource_group in (?)", resourceGroups)
 	}
 
 	if len(stmtTypes) > 0 {

--- a/pkg/apiserver/statement/service.go
+++ b/pkg/apiserver/statement/service.go
@@ -141,12 +141,13 @@ func (s *Service) stmtTypesHandler(c *gin.Context) {
 }
 
 type GetStatementsRequest struct {
-	Schemas   []string `json:"schemas" form:"schemas"`
-	StmtTypes []string `json:"stmt_types" form:"stmt_types"`
-	BeginTime int      `json:"begin_time" form:"begin_time"`
-	EndTime   int      `json:"end_time" form:"end_time"`
-	Text      string   `json:"text" form:"text"`
-	Fields    string   `json:"fields" form:"fields"`
+	Schemas        []string `json:"schemas" form:"schemas"`
+	ResourceGroups []string `json:"resource_groups" form:"resource_groups"`
+	StmtTypes      []string `json:"stmt_types" form:"stmt_types"`
+	BeginTime      int      `json:"begin_time" form:"begin_time"`
+	EndTime        int      `json:"end_time" form:"end_time"`
+	Text           string   `json:"text" form:"text"`
+	Fields         string   `json:"fields" form:"fields"`
 }
 
 // @Summary Get a list of statements
@@ -171,6 +172,7 @@ func (s *Service) listHandler(c *gin.Context) {
 		db,
 		req.BeginTime, req.EndTime,
 		req.Schemas,
+		req.ResourceGroups,
 		req.StmtTypes,
 		req.Text,
 		fields)
@@ -360,6 +362,7 @@ func (s *Service) downloadTokenHandler(c *gin.Context) {
 		db,
 		req.BeginTime, req.EndTime,
 		req.Schemas,
+		req.ResourceGroups,
 		req.StmtTypes,
 		req.Text,
 		fields)

--- a/ui/packages/tidb-dashboard-client/src/client/api/api/default-api.ts
+++ b/ui/packages/tidb-dashboard-client/src/client/api/api/default-api.ts
@@ -3144,13 +3144,14 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {number} [beginTime] 
          * @param {number} [endTime] 
          * @param {string} [fields] 
+         * @param {Array<string>} [resourceGroups] 
          * @param {Array<string>} [schemas] 
          * @param {Array<string>} [stmtTypes] 
          * @param {string} [text] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        statementsListGet: async (beginTime?: number, endTime?: number, fields?: string, schemas?: Array<string>, stmtTypes?: Array<string>, text?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        statementsListGet: async (beginTime?: number, endTime?: number, fields?: string, resourceGroups?: Array<string>, schemas?: Array<string>, stmtTypes?: Array<string>, text?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/statements/list`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -3176,6 +3177,10 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
 
             if (fields !== undefined) {
                 localVarQueryParameter['fields'] = fields;
+            }
+
+            if (resourceGroups) {
+                localVarQueryParameter['resource_groups'] = resourceGroups;
             }
 
             if (schemas) {
@@ -4945,14 +4950,15 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {number} [beginTime] 
          * @param {number} [endTime] 
          * @param {string} [fields] 
+         * @param {Array<string>} [resourceGroups] 
          * @param {Array<string>} [schemas] 
          * @param {Array<string>} [stmtTypes] 
          * @param {string} [text] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async statementsListGet(beginTime?: number, endTime?: number, fields?: string, schemas?: Array<string>, stmtTypes?: Array<string>, text?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<StatementModel>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.statementsListGet(beginTime, endTime, fields, schemas, stmtTypes, text, options);
+        async statementsListGet(beginTime?: number, endTime?: number, fields?: string, resourceGroups?: Array<string>, schemas?: Array<string>, stmtTypes?: Array<string>, text?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<StatementModel>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.statementsListGet(beginTime, endTime, fields, resourceGroups, schemas, stmtTypes, text, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -5998,14 +6004,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {number} [beginTime] 
          * @param {number} [endTime] 
          * @param {string} [fields] 
+         * @param {Array<string>} [resourceGroups] 
          * @param {Array<string>} [schemas] 
          * @param {Array<string>} [stmtTypes] 
          * @param {string} [text] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        statementsListGet(beginTime?: number, endTime?: number, fields?: string, schemas?: Array<string>, stmtTypes?: Array<string>, text?: string, options?: any): AxiosPromise<Array<StatementModel>> {
-            return localVarFp.statementsListGet(beginTime, endTime, fields, schemas, stmtTypes, text, options).then((request) => request(axios, basePath));
+        statementsListGet(beginTime?: number, endTime?: number, fields?: string, resourceGroups?: Array<string>, schemas?: Array<string>, stmtTypes?: Array<string>, text?: string, options?: any): AxiosPromise<Array<StatementModel>> {
+            return localVarFp.statementsListGet(beginTime, endTime, fields, resourceGroups, schemas, stmtTypes, text, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -7105,6 +7112,13 @@ export interface DefaultApiStatementsListGetRequest {
      * @memberof DefaultApiStatementsListGet
      */
     readonly fields?: string
+
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof DefaultApiStatementsListGet
+     */
+    readonly resourceGroups?: Array<string>
 
     /**
      * 
@@ -8404,7 +8418,7 @@ export class DefaultApi extends BaseAPI {
      * @memberof DefaultApi
      */
     public statementsListGet(requestParameters: DefaultApiStatementsListGetRequest = {}, options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).statementsListGet(requestParameters.beginTime, requestParameters.endTime, requestParameters.fields, requestParameters.schemas, requestParameters.stmtTypes, requestParameters.text, options).then((request) => request(this.axios, this.basePath));
+        return DefaultApiFp(this.configuration).statementsListGet(requestParameters.beginTime, requestParameters.endTime, requestParameters.fields, requestParameters.resourceGroups, requestParameters.schemas, requestParameters.stmtTypes, requestParameters.text, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/ui/packages/tidb-dashboard-client/src/client/api/models/statement-get-statements-request.ts
+++ b/ui/packages/tidb-dashboard-client/src/client/api/models/statement-get-statements-request.ts
@@ -43,6 +43,12 @@ export interface StatementGetStatementsRequest {
      * @type {Array<string>}
      * @memberof StatementGetStatementsRequest
      */
+    'resource_groups'?: Array<string>;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof StatementGetStatementsRequest
+     */
     'schemas'?: Array<string>;
     /**
      * 

--- a/ui/packages/tidb-dashboard-client/swagger/spec.json
+++ b/ui/packages/tidb-dashboard-client/swagger/spec.json
@@ -2759,6 +2759,15 @@
                             "type": "string"
                         },
                         "collectionFormat": "multi",
+                        "name": "resource_groups",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
                         "name": "schemas",
                         "in": "query"
                     },
@@ -5329,6 +5338,12 @@
                 },
                 "fields": {
                     "type": "string"
+                },
+                "resource_groups": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "schemas": {
                     "type": "array",

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/Statement/context.ts
@@ -49,6 +49,7 @@ class DataSource implements IStatementDataSource {
     endTime?: number,
     fields?: string,
     schemas?: Array<string>,
+    resourceGroups?: Array<string>,
     stmtTypes?: Array<string>,
     text?: string,
     options?: ReqConfig
@@ -59,6 +60,7 @@ class DataSource implements IStatementDataSource {
         endTime,
         fields,
         schemas,
+        resourceGroups,
         stmtTypes,
         text
       },

--- a/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
+++ b/ui/packages/tidb-dashboard-for-op/src/apps/Statement/context.ts
@@ -49,6 +49,7 @@ class DataSource implements IStatementDataSource {
     endTime?: number,
     fields?: string,
     schemas?: Array<string>,
+    resourceGroups?: Array<string>,
     stmtTypes?: Array<string>,
     text?: string,
     options?: ReqConfig
@@ -59,6 +60,7 @@ class DataSource implements IStatementDataSource {
         endTime,
         fields,
         schemas,
+        resourceGroups,
         stmtTypes,
         text
       },

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
@@ -178,6 +178,7 @@ function List() {
         begin_time: timeRangeValue[0],
         end_time: timeRangeValue[1],
         db: controller.queryOptions.schemas,
+        resource_group: controller.queryOptions.groups,
         text: controller.queryOptions.searchText,
         orderBy: controller.orderOptions.orderBy,
         desc: controller.orderOptions.desc,
@@ -243,7 +244,7 @@ function List() {
               />
             )}
             {ctx!.cfg.showResourceGroupFilter &&
-              controller.allGroups.length > 1 && (
+              controller.allGroups?.length > 1 && (
                 <MultiSelect.Plain
                   placeholder={t(
                     'slow_query.toolbar.resource_groups.placeholder'

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/context/index.ts
@@ -41,6 +41,7 @@ export interface IStatementDataSource extends ISlowQueryDataSource {
     endTime?: number,
     fields?: string,
     schemas?: Array<string>,
+    resourceGroups?: Array<string>,
     stmtTypes?: Array<string>,
     text?: string,
     options?: ReqConfig
@@ -91,6 +92,7 @@ export interface IStatementConfig extends IContextConfig {
   enableExport?: boolean
   showConfig?: boolean // default is true
   showDBFilter?: boolean // default is true
+  showResourceGroupFilter?: boolean // default is true
   showHelp?: boolean // default is true
 
   // control whether show statement actual time range

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/pages/List/index.tsx
@@ -98,6 +98,7 @@ export default function StatementsOverview() {
     cacheMgr,
     showFullSQL,
     fetchSchemas: ctx?.cfg.showDBFilter,
+    fetchGroups: ctx?.cfg.showResourceGroupFilter,
     fetchConfig: ctx?.cfg.showConfig,
     initialQueryOptions: {
       ...DEF_STMT_QUERY_OPTIONS,
@@ -146,6 +147,9 @@ export default function StatementsOverview() {
   const [filterSchema, setFilterSchema] = useState<string[]>(
     controller.queryOptions.schemas
   )
+  const [filterGroup, setFilterGroup] = useState<string[]>(
+    controller.queryOptions.groups
+  )
   const [filterStmtType, setFilterStmtType] = useState<string[]>(
     controller.queryOptions.stmtTypes
   )
@@ -158,6 +162,7 @@ export default function StatementsOverview() {
     controller.setQueryOptions({
       timeRange,
       schemas: filterSchema,
+      groups: filterGroup,
       stmtTypes: filterStmtType,
       searchText: filterText,
       visibleColumnKeys
@@ -179,7 +184,14 @@ export default function StatementsOverview() {
       return
     }
     sendQueryDebounced()
-  }, [timeRange, filterSchema, filterStmtType, filterText, visibleColumnKeys])
+  }, [
+    timeRange,
+    filterSchema,
+    filterGroup,
+    filterStmtType,
+    filterText,
+    visibleColumnKeys
+  ])
 
   const downloadCSV = useMemoizedFn(async () => {
     // use last effective query options
@@ -191,6 +203,7 @@ export default function StatementsOverview() {
         end_time: timeRangeValue[1],
         fields: '*',
         schemas: controller.queryOptions.schemas,
+        resource_groups: controller.queryOptions.groups,
         stmt_types: controller.queryOptions.stmtTypes,
         text: controller.queryOptions.searchText
       })
@@ -251,6 +264,26 @@ export default function StatementsOverview() {
                 data-e2e="execution_database_name"
               />
             )}
+
+            {(ctx?.cfg.showResourceGroupFilter ?? true) &&
+              controller.allGroups?.length > 1 && (
+                <MultiSelect.Plain
+                  placeholder={t(
+                    'statement.pages.overview.toolbar.resource_groups.placeholder'
+                  )}
+                  selectedValueTransKey="statement.pages.overview.toolbar.resource_groups.selected"
+                  columnTitle={t(
+                    'statement.pages.overview.toolbar.resource_groups.columnTitle'
+                  )}
+                  value={filterGroup}
+                  style={{ width: 150 }}
+                  onChange={(d) => {
+                    setFilterGroup(d)
+                  }}
+                  items={controller.allGroups}
+                  data-e2e="resource_group_name_select"
+                />
+              )}
             <MultiSelect.Plain
               placeholder={t(
                 'statement.pages.overview.toolbar.statement_types.placeholder'

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/en.yaml
@@ -42,6 +42,10 @@ statement:
           placeholder: All Databases
           selected: '{{ n }} Databases'
           columnTitle: Execution Database Name
+        resource_groups:
+          placeholder: All Resource Groups
+          selected: '{{ n }} Resource Groups'
+          columnTitle: Resource Group Name
         statement_types:
           placeholder: All Kinds
           selected_one: '{{ count }} Kind'

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/translations/zh.yaml
@@ -42,6 +42,10 @@ statement:
           placeholder: 所有数据库
           selected: '{{ n }} 数据库'
           columnTitle: 执行数据库名
+        resource_groups:
+          placeholder: 所有资源组
+          selected: '{{ n }} 资源组'
+          columnTitle: 资源组名
         statement_types:
           placeholder: 所有类型
           selected: '{{ count }} 类型'

--- a/ui/packages/tidb-dashboard-lib/src/client/models.ts
+++ b/ui/packages/tidb-dashboard-lib/src/client/models.ts
@@ -2796,6 +2796,12 @@ export interface StatementGetStatementsRequest {
      * @type {Array<string>}
      * @memberof StatementGetStatementsRequest
      */
+    'resource_groups'?: Array<string>;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof StatementGetStatementsRequest
+     */
     'schemas'?: Array<string>;
     /**
      * 


### PR DESCRIPTION
support `statement` search by resource group
- If there are above 2 resource groups in the cluster, will show the `MultiSelect`
- Add relative API

Example:
![image](https://github.com/pingcap/tidb-dashboard/assets/6428910/892af5f0-d276-49dd-9504-413b4c5e54d8)
