### PR TITLE
fix(debug-data): fix the wrong file ext for tiproxy config

### DIFF
--- a/pkg/apiserver/debugapi/apis.go
+++ b/pkg/apiserver/debugapi/apis.go
@@ -34,6 +34,11 @@ var commonParamPprofDebug = endpoint.APIParamEnum("debug", false, []endpoint.Enu
 	{Value: "2", DisplayAs: "Text Format"},
 })
 
+var commonParamConfigFormat = endpoint.APIParamEnum("format", false, []endpoint.EnumItemDefinition{
+	{Value: "toml"},
+	{Value: "json"},
+})
+
 var apiEndpoints = []endpoint.APIDefinition{
 	// TiDB Endpoints
 	{
@@ -445,6 +450,9 @@ var apiEndpoints = []endpoint.APIDefinition{
 		Component: topo.KindTiProxy,
 		Path:      "/api/admin/config",
 		Method:    resty.MethodGet,
+		QueryParams: []endpoint.APIParamDefinition{
+			commonParamConfigFormat,
+		},
 	},
 	{
 		ID:        "tiproxy_pprof",

--- a/pkg/apiserver/debugapi/service.go
+++ b/pkg/apiserver/debugapi/service.go
@@ -90,6 +90,10 @@ func getExtFromContentTypeHeader(contentType string) string {
 		return ".txt"
 	}
 
+	if mediaType == "application/toml" {
+		return ".toml"
+	}
+
 	exts, err := mime.ExtensionsByType(mediaType)
 	if err == nil && len(exts) > 0 {
 		// Note: the first element might not be the most common one


### PR DESCRIPTION
before fixing, the default file ext is `.bin`