### PR TITLE
fix(cluster_info): fix error for hosts/disks/statistics page

### DIFF
--- a/pkg/apiserver/clusterinfo/host.go
+++ b/pkg/apiserver/clusterinfo/host.go
@@ -4,6 +4,7 @@ package clusterinfo
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/pingcap/log"
 	"github.com/samber/lo"
@@ -62,7 +63,11 @@ func (s *Service) fetchAllInstanceHosts() ([]string, error) {
 
 	tsoInfo, err := topology.FetchTSOTopology(s.lifecycleCtx, s.params.PDClient)
 	if err != nil {
-		return nil, err
+		if strings.Contains(err.Error(), "status code 404") {
+			tsoInfo = []topology.TSOInfo{}
+		} else {
+			return nil, err
+		}
 	}
 	for _, i := range tsoInfo {
 		allHostsMap[i.IP] = struct{}{}
@@ -70,7 +75,11 @@ func (s *Service) fetchAllInstanceHosts() ([]string, error) {
 
 	schedulingInfo, err := topology.FetchSchedulingTopology(s.lifecycleCtx, s.params.PDClient)
 	if err != nil {
-		return nil, err
+		if strings.Contains(err.Error(), "status code 404") {
+			schedulingInfo = []topology.SchedulingInfo{}
+		} else {
+			return nil, err
+		}
 	}
 	for _, i := range schedulingInfo {
 		allHostsMap[i.IP] = struct{}{}

--- a/pkg/apiserver/clusterinfo/statistics.go
+++ b/pkg/apiserver/clusterinfo/statistics.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/samber/lo"
 	"gorm.io/gorm"
@@ -139,7 +140,11 @@ func (s *Service) calculateStatistics(db *gorm.DB) (*ClusterStatistics, error) {
 	}
 	tsoInfo, err := topology.FetchTSOTopology(s.lifecycleCtx, s.params.PDClient)
 	if err != nil {
-		return nil, err
+		if strings.Contains(err.Error(), "status code 404") {
+			tsoInfo = []topology.TSOInfo{}
+		} else {
+			return nil, err
+		}
 	}
 	for _, i := range tsoInfo {
 		globalHostsSet[i.IP] = struct{}{}
@@ -149,7 +154,11 @@ func (s *Service) calculateStatistics(db *gorm.DB) (*ClusterStatistics, error) {
 	}
 	schedulingInfo, err := topology.FetchSchedulingTopology(s.lifecycleCtx, s.params.PDClient)
 	if err != nil {
-		return nil, err
+		if strings.Contains(err.Error(), "status code 404") {
+			schedulingInfo = []topology.SchedulingInfo{}
+		} else {
+			return nil, err
+		}
 	}
 	for _, i := range schedulingInfo {
 		globalHostsSet[i.IP] = struct{}{}

--- a/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/components/Statistics.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/ClusterInfo/components/Statistics.tsx
@@ -92,11 +92,13 @@ export default function Statistics() {
             />
           </Card>
           {InstanceKinds.map((ik) => {
-            return (
+            const d = data.stats_by_instance_kind?.[ik]
+            const instNum = d?.number_of_instances ?? 0
+            return instNum > 0 ? (
               <Card title={instanceKindName(ik)} key={ik}>
-                <PartialInfo data={data.stats_by_instance_kind?.[ik]} />
+                <PartialInfo data={d} />
               </Card>
-            )
+            ) : null
           })}
         </div>
       )}


### PR DESCRIPTION
This PR fixes the following error pages:

![image](https://github.com/pingcap/tidb-dashboard/assets/1284531/8175c749-2a56-4baa-a0fc-4e42069b7a29)
![image](https://github.com/pingcap/tidb-dashboard/assets/1284531/5cfde443-5fe3-4695-aa21-803bbe4b0a08)
![image](https://github.com/pingcap/tidb-dashboard/assets/1284531/bb30f04e-0e3d-4b85-844f-2836166680ff)
