### PR TITLE
feat(slow_query): download db file for slow query

### DIFF
--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/SlowQuery/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/SlowQuery/context.ts
@@ -93,6 +93,20 @@ class DataSource implements ISlowQueryDataSource {
       .get(`/slow_query/analyze?begin_time=${start}&end_time=${end}`)
   }
 
+  slowQueryDownloadDBFile(begin_time: number, end_time: number) {
+    return client
+      .getAxiosInstance()
+      .get(
+        `/slow_query/analyze?begin_time=${begin_time}&end_time=${end_time}`,
+        {
+          responseType: 'blob',
+          headers: {
+            Accept: 'application/octet-stream'
+          }
+        }
+      )
+  }
+
   promqlQuery(query: string, time: number, timeout: string) {
     return client
       .getAxiosInstance()
@@ -139,6 +153,7 @@ export const ctx: (cfg: Partial<ISlowQueryConfig>) => ISlowQueryContext = (
       showDBFilter: true,
       showDigestFilter: false,
       showResourceGroupFilter: true,
+      showDownloadSlowQueryDBFile: true,
       ...cfg
     }
   }

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/context/index.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/context/index.ts
@@ -43,6 +43,8 @@ export interface ISlowQueryDataSource {
 
   slowQueryAnalyze?(start: number, end: number): AxiosPromise
 
+  slowQueryDownloadDBFile?(begin_time: number, end_time: number): AxiosPromise
+
   promqlQuery?(
     query: string,
     time: number,
@@ -86,6 +88,7 @@ export interface ISlowQueryConfig extends IContextConfig {
   orgName?: string
   clusterName?: string
   showTopSlowQueryLink?: boolean
+  showDownloadSlowQueryDBFile?: boolean
 }
 
 export interface ISlowQueryContext {

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/DownloadDBFileModal.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/DownloadDBFileModal.tsx
@@ -1,0 +1,119 @@
+import React, { useContext, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button, Form, Modal, Radio, Select } from 'antd'
+import { useMemoizedFn } from 'ahooks'
+import { DatePicker } from '@lib/components'
+import { SlowQueryContext } from '../../context'
+import dayjs, { Dayjs } from 'dayjs'
+
+const hoursRange = [...Array(24).keys()]
+
+function DownloadDBFileModal({
+  visible,
+  setVisible
+}: {
+  visible: boolean
+  setVisible: React.Dispatch<React.SetStateAction<boolean>>
+}) {
+  const ctx = useContext(SlowQueryContext)
+  const { t } = useTranslation()
+
+  type RangeType = 'by_day' | 'by_hour'
+
+  const [rangeTypeVal, setRangeTypeVal] = useState<RangeType>('by_day')
+  const [downloading, setDownloading] = useState(false)
+
+  const [dateVal, setDateVal] = useState(dayjs())
+  const [hourVal, setHourVal] = useState(0)
+
+  const downloadDBFile = useMemoizedFn(
+    async (dateVal: Dayjs, hourVal: number, rangeTypeVal: RangeType) => {
+      // use last effective query options
+      if (hourVal < 0 || hourVal > 23) {
+        console.log(`Illegegal hour value: ${hourVal}`)
+        hourVal = hourVal % 24
+      }
+      try {
+        setDownloading(true)
+        const offset = rangeTypeVal === 'by_day' ? 86400 : 3600
+        const dateAlignedUnix = dateVal.unix() - (dateVal.unix() % 86400)
+        const begin_time =
+          dateAlignedUnix + (rangeTypeVal === 'by_hour' ? hourVal * 3600 : 0)
+        const res = await ctx!.ds.slowQueryDownloadDBFile!(
+          begin_time,
+          begin_time + offset
+        )
+        const { data, headers } = res
+        const fileName = `${begin_time}.db`
+        const blob = new Blob([data], { type: headers['content-type'] })
+        let dom = document.createElement('a')
+        let url = window.URL.createObjectURL(blob)
+        dom.href = url
+        dom.download = decodeURI(fileName)
+        dom.style.display = 'none'
+        document.body.appendChild(dom)
+        dom.click()
+        dom.parentNode!.removeChild(dom)
+        window.URL.revokeObjectURL(url)
+      } finally {
+        setDownloading(false)
+      }
+    }
+  )
+
+  return (
+    <Modal
+      visible={visible}
+      footer={null}
+      onCancel={(e) => setVisible(false)}
+      title={t('slow_query.download_modal.title')}
+    >
+      <Form>
+        <Form.Item label="Range Type" name="layout">
+          <Radio.Group
+            onChange={(e) => setRangeTypeVal(e.target.value)}
+            defaultValue={rangeTypeVal}
+          >
+            <Radio value={'by_day'}>
+              {t('slow_query.download_modal.download_by_day')}
+            </Radio>
+            <Radio value={'by_hour'}>
+              {t('slow_query.download_modal.download_by_hour')}
+            </Radio>
+          </Radio.Group>
+        </Form.Item>
+        <Form.Item label="Date" name="date">
+          <DatePicker
+            onChange={(date) => {
+              date && setDateVal(date)
+            }}
+          />
+        </Form.Item>
+        <Form.Item label="Hour" name="hour">
+          <Select
+            defaultValue={0}
+            disabled={rangeTypeVal === 'by_day'}
+            onChange={(val) => setHourVal(val)}
+            options={hoursRange.map((i) => {
+              return {
+                key: i,
+                value: i,
+                label: `${i}:00~${(i + 1) % 24}:00`
+              }
+            })}
+          />
+        </Form.Item>
+        <Form.Item>
+          <Button
+            disabled={downloading}
+            onClick={() => downloadDBFile(dateVal, hourVal, rangeTypeVal)}
+          >
+            {t(`slow_query.download_modal.download`)}
+          </Button>
+        </Form.Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default DownloadDBFileModal

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
@@ -11,7 +11,8 @@ import {
   Alert,
   Tooltip,
   Result,
-  Tag
+  Tag,
+  Button
 } from 'antd'
 import {
   LoadingOutlined,
@@ -44,6 +45,7 @@ import { useDeepCompareChange } from '@lib/utils/useChange'
 import { isDistro } from '@lib/utils/distro'
 import { SlowQueryContext } from '../../context'
 import { Link } from 'react-router-dom'
+import DownloadDBFileModal from './DownloadDBFileModal'
 
 const { Option } = Select
 
@@ -67,6 +69,7 @@ function List() {
     { defaultValue: false }
   )
   const [downloading, setDownloading] = useState(false)
+  const [downloadModalVisible, setDownloadModalVisible] = useState(false)
 
   const { timeRange, setTimeRange } = useURLTimeRange()
 
@@ -311,6 +314,14 @@ function List() {
               data-e2e="slow_query_search"
               enterButton={t('slow_query.toolbar.query')}
             />
+            {ctx!.cfg.showDownloadSlowQueryDBFile && (
+              <Button
+                type="link"
+                onClick={() => setDownloadModalVisible(!downloadModalVisible)}
+              >
+                {t('slow_query.toolbar.download')}
+              </Button>
+            )}
             {controller.isLoading && <LoadingOutlined />}
           </Space>
           <Space>
@@ -387,6 +398,12 @@ function List() {
             <SlowQueriesTable cardNoMarginTop controller={controller} />
           </ScrollablePane>
         </div>
+      )}
+      {ctx!.cfg.showDownloadSlowQueryDBFile && (
+        <DownloadDBFileModal
+          visible={downloadModalVisible}
+          setVisible={setDownloadModalVisible}
+        />
       )}
     </div>
   )

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/en.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/en.yaml
@@ -172,3 +172,9 @@ slow_query:
     exporting: Exporting
     help: Help
     help_url: https://docs.pingcap.com/tidb/dev/dashboard-slow-query
+    download: Download
+  download_modal:
+    download: Download
+    title: 'Download Slow Query db File'
+    download_by_day: Download By Day
+    download_by_hour: Download By Hour

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/zh.yaml
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/translations/zh.yaml
@@ -174,3 +174,9 @@ slow_query:
     exporting: 正在导出
     help: 帮助
     help_url: https://docs.pingcap.com/zh/tidb/dev/dashboard-slow-query
+    download: 下载
+  download_modal:
+    download: 下载
+    title: '下载慢查询 db 文件'
+    download_by_day: 按天下载
+    download_by_hour: 按小时下载


### PR DESCRIPTION
Enable download slow query db file on slow query page in clinic-cloud.
<img width="1401" alt="image" src="https://github.com/pingcap/tidb-dashboard/assets/36335793/0d958b0a-e50e-439d-a90c-340be7e1d616">
<img width="1432" alt="image" src="https://github.com/pingcap/tidb-dashboard/assets/36335793/70b0211c-f888-4a07-bbc3-c54c4704a43d">
