### PR TITLE
fix(top-slowquery): fix db filter sometimes can not select item

### DIFF
--- a/ui/packages/tidb-dashboard-for-clinic-cloud/public/index.html
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/public/index.html
@@ -142,7 +142,7 @@
         },
         appsDisabled: [
           'topsql',
-          // 'slow_query',
+          'slow_query',
           'conprof',
           'query_editor',
           'diagnose',

--- a/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/SlowQuery/context.ts
+++ b/ui/packages/tidb-dashboard-for-clinic-cloud/src/apps/SlowQuery/context.ts
@@ -8,6 +8,15 @@ import {
 
 import client, { SlowqueryModel } from '~/client'
 
+const debugHeaders = {
+  // 'x-cluster-id': '1379661944646413143',
+  // 'x-org-id': '1372813089209061633',
+  // 'x-project-id': '1372813089454525346',
+  // 'x-provider': 'aws',
+  // 'x-region': 'us-east-1',
+  // 'x-env': 'prod'
+}
+
 class DataSource implements ISlowQueryDataSource {
   constructor(public cache: SlowqueryModel[]) {}
 
@@ -20,7 +29,10 @@ class DataSource implements ISlowQueryDataSource {
     // get database list from s3
     return client
       .getAxiosInstance()
-      .get(`/slow_query/databases?begin_time=${beginTime}&end_time=${endTime}`)
+      .get(
+        `/slow_query/databases?begin_time=${beginTime}&end_time=${endTime}`,
+        { headers: debugHeaders }
+      )
   }
 
   infoListResourceGroupNames(options?: ReqConfig) {

--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/pages/List/index.tsx
@@ -206,6 +206,13 @@ function List() {
   } = useSlowQueryListUrlState()
 
   const [defDbs, _] = useState(dbs)
+  const { data: dbsData, isFetching: fetchingDbs } = useDbsData()
+  const finalDbs = useMemo(() => {
+    if (dbsData && dbsData.length > 0) {
+      return dbsData
+    }
+    return defDbs
+  }, [defDbs, dbsData])
 
   const [visibleColumnKeys, setVisibleColumnKeys] =
     useVersionedLocalStorageState(SLOW_QUERY_VISIBLE_COLUMN_KEYS, {
@@ -218,7 +225,6 @@ function List() {
 
   const [downloadModalVisible, setDownloadModalVisible] = useState(false)
 
-  const { data: dbsData, isFetching: fetchingDbs } = useDbsData()
   const { data: ruGroupsData, isFetching: fetchingRuGroups } = useRuGroupsData()
   const { data: availableColumnsData, isFetching: fetchingAvailableColumns } =
     useAvailableColumnsData()
@@ -405,7 +411,7 @@ function List() {
                 value={dbs}
                 style={{ width: 150 }}
                 onChange={setDbs}
-                items={dbsData ?? defDbs}
+                items={finalDbs}
                 data-e2e="execution_database_name"
               />
             )}

--- a/ui/packages/tidb-dashboard-lib/src/apps/TopSlowQuery/pages/List.tsx
+++ b/ui/packages/tidb-dashboard-lib/src/apps/TopSlowQuery/pages/List.tsx
@@ -122,8 +122,7 @@ function useTimeWindows() {
 
 const timezone = dayjs().format('UTCZ')
 function TimeWindowSelect() {
-  const { duration, setDurationAndTimeRange, tw, setTw } =
-    useTopSlowQueryUrlState()
+  const { duration, setQueryParams, tw, setTw } = useTopSlowQueryUrlState()
   const { data: availableTimeWindows } = useTimeWindows()
 
   function newerTw() {
@@ -173,7 +172,11 @@ function TimeWindowSelect() {
           style={{ width: 128 }}
           value={duration}
           onChange={(v) => {
-            setDurationAndTimeRange(v, DEFAULT_TIME_RANGE)
+            setQueryParams({
+              duration: v,
+              from: DEFAULT_TIME_RANGE.value,
+              to: 'now'
+            })
             telemetry.changeDuration(v)
           }}
         >
@@ -249,7 +252,7 @@ function useChartData() {
 
 function SlowQueryCountChart() {
   const { data: chartData, isLoading } = useChartData()
-  const { tw, setDurationAndTimeRange } = useTopSlowQueryUrlState()
+  const { tw, setQueryParams } = useTopSlowQueryUrlState()
 
   function onSelectTimeRange(timeRange: TimeRangeValue) {
     const delta = timeRange[1] - timeRange[0]
@@ -267,7 +270,7 @@ function SlowQueryCountChart() {
     } else if (delta < 7 * 24 * 60 * 60) {
       duration = 7 * 24 * 60 * 60
     }
-    setDurationAndTimeRange(duration, fromTimeRangeValue(timeRange))
+    setQueryParams({ duration, from: timeRange[0], to: timeRange[0] })
   }
 
   return (
@@ -305,7 +308,7 @@ function useDatabaseList() {
 }
 
 function TopSlowQueryFilters() {
-  const { dbs, setDbs, order, setOrder, stmtKinds, setStmtKinds } =
+  const { tw, dbs, setDbs, order, setOrder, stmtKinds, setStmtKinds } =
     useTopSlowQueryUrlState()
   const { data: databaseList } = useDatabaseList()
 
@@ -313,7 +316,9 @@ function TopSlowQueryFilters() {
     <Space style={{ marginBottom: 8 }}>
       <div>
         <span>Databases: </span>
+        {/* this component has a weird bug, sometimes it can't select item after changing the time window, use `key` can fix it */}
         <MultiSelect.Plain
+          key={`${tw[0]}_${tw[1]}`}
           placeholder="All Databases"
           columnTitle="Databases"
           value={dbs}

--- a/ui/packages/tidb-dashboard-lib/src/apps/TopSlowQuery/uilts/url-state.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/TopSlowQuery/uilts/url-state.ts
@@ -57,16 +57,6 @@ export function useTopSlowQueryUrlState() {
     [setQueryParams]
   )
 
-  // Note: when calling `setDuration(); setTimeRange();` at the same time, only the last one will take effect
-  // the latter one will overwrite the former one
-  // TODO: do we have a better solution? expose the `setQueryParams` as well?
-  const setDurationAndTimeRange = useCallback(
-    (v: number, tr: TimeRange) => {
-      setQueryParams({ duration: v + '', ...toURLTimeRange(tr) })
-    },
-    [setQueryParams]
-  )
-
   const tw = useMemo(() => {
     const arr = queryParams.tw?.split('-')
     if (arr && arr.length === 2) {
@@ -91,12 +81,6 @@ export function useTopSlowQueryUrlState() {
     (v: string) => setQueryParams({ order: v }),
     [setQueryParams]
   )
-
-  // const db = queryParams.db
-  // const setDb = useCallback(
-  //   (v: string) => setQueryParams({ db: v }),
-  //   [setQueryParams]
-  // )
 
   // dbs
   const dbs = useMemo(() => {
@@ -134,16 +118,11 @@ export function useTopSlowQueryUrlState() {
     duration,
     setDuration,
 
-    setDurationAndTimeRange,
-
     tw,
     setTw,
 
     order,
     setOrder,
-
-    // db,
-    // setDb,
 
     dbs,
     setDbs,
@@ -152,6 +131,9 @@ export function useTopSlowQueryUrlState() {
     setStmtKinds,
 
     internal,
-    setInternal
+    setInternal,
+
+    queryParams,
+    setQueryParams
   }
 }


### PR DESCRIPTION
This PR fixes the bug that db filter can not select item after changing the time window, and clean up some codes.