### PR TITLE
feat: support multi batches for keyviz schema data

### DIFF
--- a/pkg/tidb/model/model.go
+++ b/pkg/tidb/model/model.go
@@ -63,6 +63,7 @@ type TableInfo struct {
 	Name      CIStr          `json:"name"`
 	Indices   []*IndexInfo   `json:"index_info"`
 	Partition *PartitionInfo `json:"partition"`
+	Version   *int64         `json:"version"`
 }
 
 // GetPartitionInfo returns the partition information.


### PR DESCRIPTION
If the TiDB kernel's API `/schema/<db>` supports new param `id_name_only`, then a batch strategy will be adopted, and only 512 tableinfos will be pulled in each batch.

Related PR: https://github.com/pingcap/tidb/pull/54608

Signed-off-by: mornyx <mornyx.z@gmail.com>