### PR TITLE
dashboard/api/host/all: add ticdc instance information to host/all api

### DIFF
--- a/pkg/apiserver/clusterinfo/hostinfo/cluster_config.go
+++ b/pkg/apiserver/clusterinfo/hostinfo/cluster_config.go
@@ -25,6 +25,7 @@ func FillInstances(db *gorm.DB, m InfoMap) error {
 		Where("(`TYPE` = 'tidb' AND `KEY` = 'log.file.filename') " +
 			"OR (`TYPE` = 'tikv' AND `KEY` = 'storage.data-dir') " +
 			"OR (`TYPE` = 'pd' AND `KEY` = 'data-dir') " +
+			"OR (`TYPE` = 'ticdc' AND `KEY` = 'data-dir')" +
 			"OR (`TYPE` = 'tiflash' AND (`KEY` = 'engine-store.path' " +
 			"    OR `KEY` = 'engine-store.storage.main.dir' " +
 			"    OR `KEY` = 'engine-store.storage.latest.dir'))").


### PR DESCRIPTION
fix for issue #1703

My change:
Inside function, Func FillInstances()
Add where clause ``OR (`TYPE` = 'ticdc' AND `KEY` = 'data-dir')"`` in the query to table INFORMATION_SCHEMA.CLUSTER_CONFIG.

