### PR TITLE
*: add share code revoke api; add a config to allow disabling custom prom addr 

### DIFF
--- a/cmd/tidb-dashboard/main.go
+++ b/cmd/tidb-dashboard/main.go
@@ -70,6 +70,7 @@ func NewCLIConfig() *DashboardCLIConfig {
 	flag.StringVar(&cfg.CoreConfig.FeatureVersion, "feature-version", cfg.CoreConfig.FeatureVersion, "target TiDB version for standalone mode")
 	flag.IntVar(&cfg.CoreConfig.NgmTimeout, "ngm-timeout", cfg.CoreConfig.NgmTimeout, "timeout secs for accessing the ngm API")
 	flag.BoolVar(&cfg.CoreConfig.EnableKeyVisualizer, "keyviz", true, "enable/disable key visualizer(default: true)")
+	flag.BoolVar(&cfg.CoreConfig.DisableCustomPromAddr, "disable-custom-prom-addr", false, "do not allow custom prometheus address")
 
 	showVersion := flag.BoolP("version", "v", false, "print version information and exit")
 

--- a/pkg/apiserver/metrics/router.go
+++ b/pkg/apiserver/metrics/router.go
@@ -142,6 +142,10 @@ func (s *Service) putCustomPromAddress(c *gin.Context) {
 		rest.Error(c, rest.ErrBadRequest.NewWithNoMessage())
 		return
 	}
+	if s.params.Config.DisableCustomPromAddr && req.Addr != "" {
+		rest.Error(c, rest.ErrForbidden.New("custom prometheus address has been disabled"))
+		return
+	}
 	addr, err := s.setCustomPromAddress(req.Addr)
 	if err != nil {
 		rest.Error(c, err)

--- a/pkg/apiserver/metrics/service.go
+++ b/pkg/apiserver/metrics/service.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/fx"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/pingcap/tidb-dashboard/pkg/config"
 	"github.com/pingcap/tidb-dashboard/pkg/httpc"
 	"github.com/pingcap/tidb-dashboard/pkg/pd"
 )
@@ -29,6 +30,7 @@ const (
 
 type ServiceParams struct {
 	fx.In
+	Config     *config.Config
 	HTTPClient *httpc.Client
 	EtcdClient *clientv3.Client
 	PDClient   *pd.Client

--- a/pkg/apiserver/user/code/router.go
+++ b/pkg/apiserver/user/code/router.go
@@ -17,6 +17,7 @@ func registerRouter(r *gin.RouterGroup, auth *user.AuthService, s *Service) {
 	endpoint := r.Group("/user/share")
 	endpoint.Use(auth.MWAuthRequired())
 	endpoint.POST("/code", auth.MWRequireSharePriv(), s.ShareHandler)
+	endpoint.POST("/revoke", auth.MWRequireSharePriv(), s.RevokeHandler)
 }
 
 type ShareRequest struct {
@@ -56,4 +57,14 @@ func (s *Service) ShareHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, ShareResponse{Code: *code})
+}
+
+// @ID userRevokeSession
+// @Summary Reset encryption key to revoke all authorized codes
+// @Security JwtAuth
+// @Success 200
+// @Router /user/share/revoke [post]
+func (s *Service) RevokeHandler(c *gin.Context) {
+	s.ResetEncryptionKey()
+	c.JSON(http.StatusOK, nil)
 }

--- a/pkg/apiserver/user/code/service.go
+++ b/pkg/apiserver/user/code/service.go
@@ -111,9 +111,11 @@ func (s *Service) SharingCodeFromSession(session *utils.SessionUser, expireIn ti
 }
 
 func (s *Service) ResetEncryptionKey() {
+	//nolint:gosec // Using unsafe is necessary because atomic pointer operations are required.
 	atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&s.sharingSecret)), unsafe.Pointer(cryptopasta.NewEncryptionKey()))
 }
 
 func (s *Service) loadShareingSecret() *[32]byte {
+	//nolint:gosec // Using unsafe is necessary because atomic pointer operations are required.
 	return (*[32]byte)(atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&s.sharingSecret))))
 }

--- a/pkg/apiserver/user/code/service.go
+++ b/pkg/apiserver/user/code/service.go
@@ -5,7 +5,9 @@ package code
 import (
 	"encoding/hex"
 	"fmt"
+	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/gtank/cryptopasta"
 	"github.com/joomcode/errorx"
@@ -52,7 +54,7 @@ func (s *Service) NewSessionFromSharingCode(codeInHex string) *utils.SessionUser
 		return nil
 	}
 
-	b, err := cryptopasta.Decrypt(encrypted, s.sharingSecret)
+	b, err := cryptopasta.Decrypt(encrypted, s.loadShareingSecret())
 	if err != nil {
 		return nil
 	}
@@ -99,11 +101,19 @@ func (s *Service) SharingCodeFromSession(session *utils.SessionUser, expireIn ti
 		return nil
 	}
 
-	encrypted, err := cryptopasta.Encrypt(b, s.sharingSecret)
+	encrypted, err := cryptopasta.Encrypt(b, s.loadShareingSecret())
 	if err != nil {
 		return nil
 	}
 
 	codeInHex := hex.EncodeToString(encrypted)
 	return &codeInHex
+}
+
+func (s *Service) ResetEncryptionKey() {
+	atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&s.sharingSecret)), unsafe.Pointer(cryptopasta.NewEncryptionKey()))
+}
+
+func (s *Service) loadShareingSecret() *[32]byte {
+	return (*[32]byte)(atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&s.sharingSecret))))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,28 +30,30 @@ type Config struct {
 	ClusterTLSInfo   *transport.TLSInfo // TLS info for mTLS authentication between TiDB components.
 	TiDBTLSConfig    *tls.Config        // TLS config for mTLS authentication between TiDB and MySQL client.
 
-	EnableTelemetry     bool
-	EnableExperimental  bool
-	EnableKeyVisualizer bool
-	FeatureVersion      string // assign the target TiDB version when running TiDB Dashboard as standalone mode
+	EnableTelemetry       bool
+	EnableExperimental    bool
+	EnableKeyVisualizer   bool
+	DisableCustomPromAddr bool
+	FeatureVersion        string // assign the target TiDB version when running TiDB Dashboard as standalone mode
 
 	NgmTimeout int // in seconds
 }
 
 func Default() *Config {
 	return &Config{
-		DataDir:             "/tmp/dashboard-data",
-		TempDir:             "",
-		PDEndPoint:          "http://127.0.0.1:2379",
-		PublicPathPrefix:    defaultPublicPathPrefix,
-		ClusterTLSConfig:    nil,
-		ClusterTLSInfo:      nil,
-		TiDBTLSConfig:       nil,
-		EnableTelemetry:     false,
-		EnableExperimental:  false,
-		EnableKeyVisualizer: true,
-		FeatureVersion:      version.PDVersion,
-		NgmTimeout:          30, // s
+		DataDir:               "/tmp/dashboard-data",
+		TempDir:               "",
+		PDEndPoint:            "http://127.0.0.1:2379",
+		PublicPathPrefix:      defaultPublicPathPrefix,
+		ClusterTLSConfig:      nil,
+		ClusterTLSInfo:        nil,
+		TiDBTLSConfig:         nil,
+		EnableTelemetry:       false,
+		EnableExperimental:    false,
+		EnableKeyVisualizer:   true,
+		DisableCustomPromAddr: false,
+		FeatureVersion:        version.PDVersion,
+		NgmTimeout:            30, // s
 	}
 }
 


### PR DESCRIPTION
- **add share code revoke api**: In the past, we could not revoke the authorization code obtained through "Share TiDB Dashboard Sessions" and could only wait for it to expire. I added a new API to revoke all authorization codes by resetting the key.
- **add a config to allow disabling custom prom addr**: For security reasons, we need to introduce a configuration item to disable the custom promtheus address to avoid SSRF attacks.