### PR TITLE
chore(statement_slowquery): ignore resource manager api error

### DIFF
--- a/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/utils/useSlowQueryTableController.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/SlowQuery/utils/useSlowQueryTableController.ts
@@ -191,7 +191,7 @@ export default function useSlowQueryTableController({
         })
         setAllGroups(res?.data || [])
       } catch (e) {
-        setErrors((prev) => prev.concat(e as Error))
+        // setErrors((prev) => prev.concat(e as Error))
       }
     }
 

--- a/ui/packages/tidb-dashboard-lib/src/apps/Statement/utils/useStatementTableController.ts
+++ b/ui/packages/tidb-dashboard-lib/src/apps/Statement/utils/useStatementTableController.ts
@@ -233,7 +233,7 @@ export default function useStatementTableController({
         })
         setAllGroups(res?.data || [])
       } catch (e) {
-        setErrors((prev) => prev.concat(e as Error))
+        // setErrors((prev) => prev.concat(e as Error))
       }
     }
 


### PR DESCRIPTION
resource manager feature only works above 7.0.0 version, so we can ignore the error below 7.0.0 version.